### PR TITLE
Update for 0.6.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
 
     dotPsci: ["<%=libFiles%>"],
   
-    docgen: {
+    pscDocs: {
       readme: {
         src: "src/**/*.purs",
         dest: "README.md"
@@ -53,6 +53,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks("grunt-purescript");
  
   grunt.registerTask("test", ["pscMake:tests", "copy", "execute:tests"]);
-  grunt.registerTask("make", ["pscMake:lib", "dotPsci", "docgen:readme"]);
+  grunt.registerTask("make", ["pscMake:lib", "dotPsci", "pscDocs:readme"]);
   grunt.registerTask("default", ["clean", "make", "test"]);
 };

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@
     newtype LazyList a where
       LazyList :: List a -> LazyList a
 
-    type List  = L.ListT Lazy
+    type List = L.ListT Lazy
 
 
 ### Type Class Instances

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-execute": "~0.1.5",
-    "grunt-purescript": "~0.5.0"
+    "grunt-purescript": "~0.6.0"
   }
 }

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -218,10 +218,10 @@ null Nil = true
 null _ = false
 
 span :: forall a. (a -> Boolean) -> List a -> Tuple (List a) (List a)
-span p (Cons x xs) | p x = 
-  case span p xs of
-    Tuple ys zs -> Tuple (Cons x ys) zs
-span _ xs = Tuple Nil xs
+span p xs@(Cons x xs') 
+  | p x = case span p xs' of
+            Tuple ys zs -> Tuple (Cons x ys) zs
+  | otherwise = Tuple Nil xs
 
 group :: forall a. (Eq a) => List a -> List (List a)
 group = groupBy (==)


### PR DESCRIPTION
@garyb @joneshf @jdegoes Could you please review?

To parse multiple guards, every guard needs to be equally indented, and in 0.6.1 this means that the body of the guard needs to be more indented than its expression, which breaks `purescript-lists` and `purescript-maps`.

This also updates the Gruntfile to use `grunt-purescript-0.6.0` and `pscDocs`.
