### PR TITLE
Update purescript-unfoldable dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "purescript-arrays"               : "~0.2.1",
     "purescript-maybe"                : "~0.2.1",
     "purescript-foldable-traversable" : "~0.1.4",
-    "purescript-unfoldable"           : "~0.1.0",
+    "purescript-unfoldable"           : "~0.2.0",
     "purescript-transformers"         : "~0.3.0",
     "purescript-lazy"                 : "~0.1.1",
     "purescript-strings"              : "~0.4.1",


### PR DESCRIPTION
Fixes the following error for me, which started after upgrading to purescript 0.6.2

```
Multiple errors:

Error at /Users/ryanartecona/Code/PureScript/purescript-markdown/bower_components/purescript-unfoldable/src/Data/Unfoldable.purs line 11, column 1 - line 16, column 1:
Error in module Data.Unfoldable
Unknown type 'STArray'

Error at /Users/ryanartecona/Code/PureScript/purescript-markdown/bower_components/purescript-unfoldable/src/Data/Unfoldable.purs line 17, column 26 - line 31, column 16:
Error in module Data.Unfoldable
Unknown value 'runSTArray'
```
