### PR TITLE
Fix inconsistent behavior of range function

### DIFF
--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -135,7 +135,7 @@ infix 8 ..
 
 -- | Create a list containing a range of integers, including both endpoints.
 range :: Int -> Int -> List Int
-range start end | start == end = Nil
+range start end | start == end = singleton start
                 | otherwise = go end start (if start > end then 1 else -1) Nil
   where
   go s e step tail | s == e = (Cons s tail)

--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -159,7 +159,7 @@ singleton a = cons a nil
 
 -- | Create a list containing a range of integers, including both endpoints.
 range :: Int -> Int -> List Int
-range start end | start == end = nil
+range start end | start == end = singleton start
                 | otherwise = go end start (if start > end then 1 else -1) nil
   where
   go s e step tail | s == e = (cons s tail)


### PR DESCRIPTION
The following behavior of the range function seems inconsistent to me (it *is* inconsistent with `Data.Array.range`)
```purescript
0 .. 2 == 0 : 1 : 2 : Nil
0 .. 1 == 0 : 1 : Nil
0 .. 0 == Nil -- would expect this to be 0 : Nil
```
The appended fix modifies the behavior of `range` to return `singleton 0` in the last case.