### PR TITLE
Fix shadow and pattern warnings

### DIFF
--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -138,15 +138,15 @@ range :: Int -> Int -> List Int
 range start end | start == end = singleton start
                 | otherwise = go end start (if start > end then 1 else -1) Nil
   where
-  go s e step tail | s == e = (Cons s tail)
-                   | otherwise = go (s + step) e step (Cons s tail)
+  go s e step rest | s == e = (Cons s rest)
+                   | otherwise = go (s + step) e step (Cons s rest)
 
 -- | Create a list with repeated instances of a value.
 replicate :: forall a. Int -> a -> List a
 replicate n value = go n Nil
   where
-  go n tail | n <= 0 = tail
-            | otherwise = go (n - 1) (Cons value tail)
+  go n rest | n <= 0 = rest
+            | otherwise = go (n - 1) (Cons value rest)
 
 -- | Perform a monadic action `n` times collecting all of the results.
 replicateM :: forall m a. (Monad m) => Int -> m a -> m (List a)

--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -162,8 +162,8 @@ range :: Int -> Int -> List Int
 range start end | start == end = singleton start
                 | otherwise = go end start (if start > end then 1 else -1) nil
   where
-  go s e step tail | s == e = (cons s tail)
-                   | otherwise = go (s + step) e step (cons s tail)
+  go s e step' rest | s == e = (cons s rest)
+                    | otherwise = go (s + step') e step' (cons s rest)
 
 -- | Create a list by repeating an element
 repeat :: forall a. a -> List a

--- a/src/Data/List/Unsafe.js
+++ b/src/Data/List/Unsafe.js
@@ -1,0 +1,8 @@
+/* global exports */
+"use strict";
+
+// module Data.List.Unsafe
+
+exports.unsafeThrow = function (msg) {
+  throw new Error(msg);
+};

--- a/src/Data/List/Unsafe.purs
+++ b/src/Data/List/Unsafe.purs
@@ -3,7 +3,12 @@
 -- | _Note_: these functions should be used with care, and may result in unspecified
 -- | behavior, including runtime exceptions.
 
-module Data.List.Unsafe where
+module Data.List.Unsafe
+  ( head
+  , tail
+  , last
+  , init
+  ) where
 
 import Prelude
 import Data.List (List(..))
@@ -13,12 +18,14 @@ import Data.List (List(..))
 -- | Running time: `O(1)`.
 head :: forall a. List a -> a
 head (Cons x _) = x
+head Nil = unsafeThrow "Data.List.Unsafe.head called on empty list"
 
 -- | Get all but the first element of a non-empty list.
 -- |
 -- | Running time: `O(1)`
 tail :: forall a. List a -> List a
 tail (Cons _ xs) = xs
+tail Nil = unsafeThrow "Data.List.Unsafe.tail called on empty list"
 
 -- | Get the last element of a non-empty list.
 -- |
@@ -26,6 +33,7 @@ tail (Cons _ xs) = xs
 last :: forall a. List a -> a
 last (Cons x Nil) = x
 last (Cons _ xs)  = last xs
+last Nil = unsafeThrow "Data.List.Unsafe.last called on empty list"
 
 -- | Get all but the last element of a non-empty list.
 -- |
@@ -33,3 +41,6 @@ last (Cons _ xs)  = last xs
 init :: forall a. List a -> List a
 init (Cons x Nil) = Nil
 init (Cons x xs)  = Cons x (init xs)
+init Nil = unsafeThrow "Data.List.Unsafe.init called on empty list"
+
+foreign import unsafeThrow :: forall a. String -> a

--- a/src/Data/List/ZipList.purs
+++ b/src/Data/List/ZipList.purs
@@ -65,5 +65,3 @@ instance plusZipList :: Plus ZipList where
   empty = mempty
 
 instance alternativeZipList :: Alternative ZipList
-
-

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -10,16 +10,16 @@ import Test.Assert (assert)
 
 testList = do
 
-  log "singleton should construct an array with a single value"
+  log "singleton should construct an list with a single value"
   assert $ singleton 1 == toList [1]
   assert $ singleton "foo" == toList ["foo"]
   assert $ singleton nil == toList [toList []]
 
-  log "range should create an inclusive array of integers for the specified start and end"
+  log "range should create an inclusive list of integers for the specified start and end"
   assert $ (range 0 5) == toList [0, 1, 2, 3, 4, 5]
   assert $ (range 2 (-3)) == toList [2, 1, 0, -1, -2, -3]
 
-  log "replicate should produce an array containg an item a specified number of times"
+  log "replicate should produce an list containg an item a specified number of times"
   assert $ replicate 3 true == toList [true, true, true]
   assert $ replicate 1 "foo" == toList ["foo"]
   assert $ replicate 0 "foo" == toList []
@@ -34,59 +34,59 @@ testList = do
   -- some
   -- many
 
-  log "null should return false for non-empty arrays"
+  log "null should return false for non-empty lists"
   assert $ null (toList [1]) == false
   assert $ null (toList [1, 2, 3]) == false
 
-  log "null should return true for an empty array"
+  log "null should return true for an empty list"
   assert $ null nil == true
 
-  log "length should return the number of items in an array"
+  log "length should return the number of items in an list"
   assert $ length nil == 0
   assert $ length (toList [1]) == 1
   assert $ length (toList [1, 2, 3, 4, 5]) == 5
 
-  log "snoc should add an item to the end of an array"
+  log "snoc should add an item to the end of an list"
   assert $ toList [1, 2, 3] `snoc` 4 == toList [1, 2, 3, 4]
   assert $ nil `snoc` 1 == toList [1]
 
-  log "insert should add an item at the appropriate place in a sorted array"
+  log "insert should add an item at the appropriate place in a sorted list"
   assert $ insert 1.5 (toList [1.0, 2.0, 3.0]) == toList [1.0, 1.5, 2.0, 3.0]
   assert $ insert 4 (toList [1, 2, 3]) == toList [1, 2, 3, 4]
   assert $ insert 0 (toList [1, 2, 3]) == toList [0, 1, 2, 3]
 
-  log "insertBy should add an item at the appropriate place in a sorted array using the specified comparison"
+  log "insertBy should add an item at the appropriate place in a sorted list using the specified comparison"
   assert $ insertBy (flip compare) 4 (toList [1, 2, 3]) == toList [4, 1, 2, 3]
   assert $ insertBy (flip compare) 0 (toList [1, 2, 3]) == toList [1, 2, 3, 0]
 
-  log "head should return a Just-wrapped first value of a non-empty array"
+  log "head should return a Just-wrapped first value of a non-empty list"
   assert $ head (toList ["foo", "bar"]) == Just "foo"
 
-  log "head should return Nothing for an empty array"
+  log "head should return Nothing for an empty list"
   assert $ head nil == Nothing
 
-  log "last should return a Just-wrapped last value of a non-empty array"
+  log "last should return a Just-wrapped last value of a non-empty list"
   assert $ last (toList ["foo", "bar"]) == Just "bar"
 
-  log "last should return Nothing for an empty array"
+  log "last should return Nothing for an empty list"
   assert $ last nil == Nothing
 
-  log "tail should return a Just-wrapped array containing all the items in an array apart from the first for a non-empty array"
+  log "tail should return a Just-wrapped list containing all the items in an list apart from the first for a non-empty list"
   assert $ tail (toList ["foo", "bar", "baz"]) == Just (toList ["bar", "baz"])
 
-  log "tail should return Nothing for an empty array"
+  log "tail should return Nothing for an empty list"
   assert $ tail nil == Nothing
 
-  log "init should return a Just-wrapped array containing all the items in an array apart from the first for a non-empty array"
+  log "init should return a Just-wrapped list containing all the items in an list apart from the first for a non-empty list"
   assert $ init (toList ["foo", "bar", "baz"]) == Just (toList ["foo", "bar"])
 
-  log "init should return Nothing for an empty array"
+  log "init should return Nothing for an empty list"
   assert $ init nil == Nothing
 
-  log "uncons should return nothing when used on an empty array"
+  log "uncons should return nothing when used on an empty list"
   assert $ isNothing (uncons nil)
 
-  log "uncons should split an array into a head and tail record when there is at least one item"
+  log "uncons should split an list into a head and tail record when there is at least one item"
   let u1 = uncons (toList [1])
   assert $ (fromJust u1).head == 1
   assert $ (fromJust u1).tail == toList []
@@ -94,28 +94,28 @@ testList = do
   assert $ (fromJust u2).head == 1
   assert $ (fromJust u2).tail == toList [2, 3]
 
-  log "(!!) should return Just x when the index is within the bounds of the array"
+  log "(!!) should return Just x when the index is within the bounds of the list"
   assert $ toList [1, 2, 3] !! 0 == (Just 1)
   assert $ toList [1, 2, 3] !! 1 == (Just 2)
   assert $ toList [1, 2, 3] !! 2 == (Just 3)
 
-  log "(!!) should return Nothing when the index is outside of the bounds of the array"
+  log "(!!) should return Nothing when the index is outside of the bounds of the list"
   assert $ toList [1, 2, 3] !! 6 == Nothing
   assert $ toList [1, 2, 3] !! (-1) == Nothing
 
-  log "elemIndex should return the index of an item that a predicate returns true for in an array"
+  log "elemIndex should return the index of an item that a predicate returns true for in an list"
   assert $ elemIndex 1 (toList [1, 2, 1]) == Just 0
   assert $ elemIndex 4 (toList [1, 2, 1]) == Nothing
 
-  log "elemLastIndex should return the last index of an item in an array"
+  log "elemLastIndex should return the last index of an item in an list"
   assert $ elemLastIndex 1 (toList [1, 2, 1]) == Just 2
   assert $ elemLastIndex 4 (toList [1, 2, 1]) == Nothing
 
-  log "findIndex should return the index of an item that a predicate returns true for in an array"
+  log "findIndex should return the index of an item that a predicate returns true for in an list"
   assert $ findIndex (/= 1) (toList [1, 2, 1]) == Just 1
   assert $ findIndex (== 3) (toList [1, 2, 1]) == Nothing
 
-  log "findLastIndex should return the last index of an item in an array"
+  log "findLastIndex should return the last index of an item in an list"
   assert $ findLastIndex (/= 1) (toList [2, 1, 2]) == Just 2
   assert $ findLastIndex (== 3) (toList [2, 1, 2]) == Nothing
 
@@ -159,11 +159,11 @@ testList = do
   log "alterAt should return Nothing if the index is out of range"
   assert $ (alterAt 1 (Just <<< (+ 1)) nil) == Nothing
 
-  log "reverse should reverse the order of items in an array"
+  log "reverse should reverse the order of items in an list"
   assert $ (reverse (toList [1, 2, 3])) == toList [3, 2, 1]
   assert $ (reverse nil) == nil
 
-  log "concat should join an array of arrays"
+  log "concat should join an list of lists"
   assert $ (concat (toList [toList [1, 2], toList [3, 4]])) == toList [1, 2, 3, 4]
   assert $ (concat (toList [toList [1], nil])) == toList [1]
   assert $ (concat (toList [nil, nil])) == nil
@@ -178,10 +178,10 @@ testList = do
   assert $ filterM (Just <<< odd) (range 0 10) == Just (toList [1, 3, 5, 7, 9])
   assert $ filterM (const Nothing) (range 0 10) == Nothing
 
-  log "mapMaybe should transform every item in an array, throwing out Nothing values"
+  log "mapMaybe should transform every item in an list, throwing out Nothing values"
   assert $ mapMaybe (\x -> if x /= 0 then Just x else Nothing) (toList [0, 1, 0, 0, 2, 3]) == toList [1, 2, 3]
 
-  log "catMaybe should take an array of Maybe values and throw out Nothings"
+  log "catMaybe should take an list of Maybe values and throw out Nothings"
   assert $ catMaybes (toList [Nothing, Just 2, Nothing, Just 4]) == toList [2, 4]
 
   log "sort should reorder a list into ascending order based on the result of compare"
@@ -190,38 +190,38 @@ testList = do
   log "sortBy should reorder a list into ascending order based on the result of a comparison function"
   assert $ sortBy (flip compare) (toList [1, 3, 2, 5, 6, 4]) == toList [6, 5, 4, 3, 2, 1]
 
-  log "take should keep the specified number of items from the front of an array, discarding the rest"
+  log "take should keep the specified number of items from the front of an list, discarding the rest"
   assert $ (take 1 (toList [1, 2, 3])) == toList [1]
   assert $ (take 2 (toList [1, 2, 3])) == toList [1, 2]
   assert $ (take 1 nil) == nil
 
-  log "takeWhile should keep all values that match a predicate from the front of an array"
+  log "takeWhile should keep all values that match a predicate from the front of an list"
   assert $ (takeWhile (/= 2) (toList [1, 2, 3])) == toList [1]
   assert $ (takeWhile (/= 3) (toList [1, 2, 3])) == toList [1, 2]
   assert $ (takeWhile (/= 1) nil) == nil
 
-  log "drop should remove the specified number of items from the front of an array"
+  log "drop should remove the specified number of items from the front of an list"
   assert $ (drop 1 (toList [1, 2, 3])) == toList [2, 3]
   assert $ (drop 2 (toList [1, 2, 3])) == toList [3]
   assert $ (drop 1 nil) == nil
 
-  log "dropWhile should remove all values that match a predicate from the front of an array"
+  log "dropWhile should remove all values that match a predicate from the front of an list"
   assert $ (dropWhile (/= 1) (toList [1, 2, 3])) == toList [1, 2, 3]
   assert $ (dropWhile (/= 2) (toList [1, 2, 3])) == toList [2, 3]
   assert $ (dropWhile (/= 1) nil) == nil
 
-  log "span should split an array in two based on a predicate"
+  log "span should split an list in two based on a predicate"
   let spanResult = span (< 4) (toList [1, 2, 3, 4, 5, 6, 7])
   assert $ spanResult.init == toList [1, 2, 3]
   assert $ spanResult.rest == toList [4, 5, 6, 7]
 
-  log "group should group consecutive equal elements into arrays"
+  log "group should group consecutive equal elements into lists"
   assert $ group (toList [1, 2, 2, 3, 3, 3, 1]) == toList [toList [1], toList [2, 2], toList [3, 3, 3], toList [1]]
 
-  log "group' should sort then group consecutive equal elements into arrays"
+  log "group' should sort then group consecutive equal elements into lists"
   assert $ group' (toList [1, 2, 2, 3, 3, 3, 1]) == toList [toList [1, 1], toList [2, 2], toList [3, 3, 3]]
 
-  log "groupBy should group consecutive equal elements into arrays based on an equivalence relation"
+  log "groupBy should group consecutive equal elements into lists based on an equivalence relation"
   assert $ groupBy (\x y -> odd x && odd y) (toList [1, 1, 2, 2, 3, 3]) == toList [toList [1, 1], toList [2], toList [2], toList [3, 3]]
 
   log "nub should remove duplicate items from the list"
@@ -231,28 +231,28 @@ testList = do
   let nubPred = \x y -> if odd x then false else x == y
   assert $ nubBy nubPred (toList [1, 2, 2, 3, 3, 4, 4, 1]) == toList [1, 2, 3, 3, 4, 1]
 
-  log "union should produce the union of two arrays"
+  log "union should produce the union of two lists"
   assert $ union (toList [1, 2, 3]) (toList [2, 3, 4]) == toList [1, 2, 3, 4]
   assert $ union (toList [1, 1, 2, 3]) (toList [2, 3, 4]) == toList [1, 1, 2, 3, 4]
 
-  log "unionBy should produce the union of two arrays using the specified equality relation"
+  log "unionBy should produce the union of two lists using the specified equality relation"
   assert $ unionBy (\_ y -> y < 5) (toList [1, 2, 3]) (toList [2, 3, 4, 5, 6]) == toList [1, 2, 3, 5, 6]
 
-  log "delete should remove the first matching item from an array"
+  log "delete should remove the first matching item from an list"
   assert $ delete 1 (toList [1, 2, 1]) == toList [2, 1]
   assert $ delete 2 (toList [1, 2, 1]) == toList [1, 1]
 
-  log "deleteBy should remove the first equality-relation-matching item from an array"
+  log "deleteBy should remove the first equality-relation-matching item from an list"
   assert $ deleteBy (/=) 2 (toList [1, 2, 1]) == toList [2, 1]
   assert $ deleteBy (/=) 1 (toList [1, 2, 1]) == toList [1, 1]
 
   log "(\\\\) should return the difference between two lists"
   assert $ toList [1, 2, 3, 4, 3, 2, 1] \\ toList [1, 1, 2, 3] == toList [4, 3, 2]
 
-  log "intersect should return the intersection of two arrays"
+  log "intersect should return the intersection of two lists"
   assert $ intersect (toList [1, 2, 3, 4, 3, 2, 1]) (toList [1, 1, 2, 3]) == toList [1, 2, 3, 3, 2, 1]
 
-  log "intersectBy should return the intersection of two arrays using the specified equivalence relation"
+  log "intersectBy should return the intersection of two lists using the specified equivalence relation"
   assert $ intersectBy (\x y -> (x * 2) == y) (toList [1, 2, 3]) (toList [2, 6]) == toList [1, 3]
 
   log "zipWith should use the specified function to zip two lists together"

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -10,16 +10,16 @@ import Test.Assert (assert)
 
 testListLazy = do
 
-  log "singleton should construct an array with a single value"
+  log "singleton should construct an list with a single value"
   assert $ singleton 1 == toList [1]
   assert $ singleton "foo" == toList ["foo"]
   assert $ singleton nil' == toList [toList []]
 
-  log "range should create an inclusive array of integers for the specified start and end"
+  log "range should create an inclusive list of integers for the specified start and end"
   assert $ (range 0 5) == toList [0, 1, 2, 3, 4, 5]
   assert $ (range 2 (-3)) == toList [2, 1, 0, -1, -2, -3]
 
-  -- log "replicate should produce an array containg an item a specified number of times"
+  -- log "replicate should produce an list containg an item a specified number of times"
   -- assert $ replicate 3 true == toList [true, true, true]
   -- assert $ replicate 1 "foo" == toList ["foo"]
   -- assert $ replicate 0 "foo" == toList []
@@ -34,59 +34,59 @@ testListLazy = do
   -- some
   -- many
 
-  log "null should return false for non-empty arrays"
+  log "null should return false for non-empty lists"
   assert $ null (toList [1]) == false
   assert $ null (toList [1, 2, 3]) == false
 
-  log "null should return true for an empty array"
+  log "null should return true for an empty list"
   assert $ null nil' == true
 
-  log "length should return the number of items in an array"
+  log "length should return the number of items in an list"
   assert $ length nil' == 0
   assert $ length (toList [1]) == 1
   assert $ length (toList [1, 2, 3, 4, 5]) == 5
 
-  -- log "snoc should add an item to the end of an array"
+  -- log "snoc should add an item to the end of an list"
   -- assert $ toList [1, 2, 3] `snoc` 4 == toList [1, 2, 3, 4]
   -- assert $ nil' `snoc` 1 == toList [1]
 
-  log "insert should add an item at the appropriate place in a sorted array"
+  log "insert should add an item at the appropriate place in a sorted list"
   assert $ insert 1.5 (toList [1.0, 2.0, 3.0]) == toList [1.0, 1.5, 2.0, 3.0]
   assert $ insert 4 (toList [1, 2, 3]) == toList [1, 2, 3, 4]
   assert $ insert 0 (toList [1, 2, 3]) == toList [0, 1, 2, 3]
 
-  log "insertBy should add an item at the appropriate place in a sorted array using the specified comparison"
+  log "insertBy should add an item at the appropriate place in a sorted list using the specified comparison"
   assert $ insertBy (flip compare) 4 (toList [1, 2, 3]) == toList [4, 1, 2, 3]
   assert $ insertBy (flip compare) 0 (toList [1, 2, 3]) == toList [1, 2, 3, 0]
 
-  log "head should return a Just-wrapped first value of a non-empty array"
+  log "head should return a Just-wrapped first value of a non-empty list"
   assert $ head (toList ["foo", "bar"]) == Just "foo"
 
-  log "head should return Nothing for an empty array"
+  log "head should return Nothing for an empty list"
   assert $ head nil' == Nothing
 
-  log "last should return a Just-wrapped last value of a non-empty array"
+  log "last should return a Just-wrapped last value of a non-empty list"
   assert $ last (toList ["foo", "bar"]) == Just "bar"
 
-  log "last should return Nothing for an empty array"
+  log "last should return Nothing for an empty list"
   assert $ last nil' == Nothing
 
-  log "tail should return a Just-wrapped array containing all the items in an array apart from the first for a non-empty array"
+  log "tail should return a Just-wrapped list containing all the items in an list apart from the first for a non-empty list"
   assert $ tail (toList ["foo", "bar", "baz"]) == Just (toList ["bar", "baz"])
 
-  log "tail should return Nothing for an empty array"
+  log "tail should return Nothing for an empty list"
   assert $ tail nil' == Nothing
 
-  log "init should return a Just-wrapped array containing all the items in an array apart from the first for a non-empty array"
+  log "init should return a Just-wrapped list containing all the items in an list apart from the first for a non-empty list"
   assert $ init (toList ["foo", "bar", "baz"]) == Just (toList ["foo", "bar"])
 
-  log "init should return Nothing for an empty array"
+  log "init should return Nothing for an empty list"
   assert $ init nil' == Nothing
 
-  log "uncons should return nothing when used on an empty array"
+  log "uncons should return nothing when used on an empty list"
   assert $ isNothing (uncons nil')
 
-  log "uncons should split an array into a head and tail record when there is at least one item"
+  log "uncons should split an list into a head and tail record when there is at least one item"
   let u1 = uncons (toList [1])
   assert $ (fromJust u1).head == 1
   assert $ (fromJust u1).tail == toList []
@@ -94,28 +94,28 @@ testListLazy = do
   assert $ (fromJust u2).head == 1
   assert $ (fromJust u2).tail == toList [2, 3]
 
-  log "(!!) should return Just x when the index is within the bounds of the array"
+  log "(!!) should return Just x when the index is within the bounds of the list"
   assert $ toList [1, 2, 3] !! 0 == (Just 1)
   assert $ toList [1, 2, 3] !! 1 == (Just 2)
   assert $ toList [1, 2, 3] !! 2 == (Just 3)
 
-  log "(!!) should return Nothing when the index is outside of the bounds of the array"
+  log "(!!) should return Nothing when the index is outside of the bounds of the list"
   assert $ toList [1, 2, 3] !! 6 == Nothing
   assert $ toList [1, 2, 3] !! (-1) == Nothing
 
-  -- log "elemIndex should return the index of an item that a predicate returns true for in an array"
+  -- log "elemIndex should return the index of an item that a predicate returns true for in an list"
   -- assert $ elemIndex 1 (toList [1, 2, 1]) == Just 0
   -- assert $ elemIndex 4 (toList [1, 2, 1]) == Nothing
 
-  -- log "elemLastIndex should return the last index of an item in an array"
+  -- log "elemLastIndex should return the last index of an item in an list"
   -- assert $ elemLastIndex 1 (toList [1, 2, 1]) == Just 2
   -- assert $ elemLastIndex 4 (toList [1, 2, 1]) == Nothing
 
-  -- log "findIndex should return the index of an item that a predicate returns true for in an array"
+  -- log "findIndex should return the index of an item that a predicate returns true for in an list"
   -- assert $ findIndex (/= 1) (toList [1, 2, 1]) == Just 1
   -- assert $ findIndex (== 3) (toList [1, 2, 1]) == Nothing
 
-  -- log "findLastIndex should return the last index of an item in an array"
+  -- log "findLastIndex should return the last index of an item in an list"
   -- assert $ findLastIndex (/= 1) (toList [2, 1, 2]) == Just 2
   -- assert $ findLastIndex (== 3) (toList [2, 1, 2]) == Nothing
 
@@ -144,11 +144,11 @@ testListLazy = do
   assert $ (alterAt 0 (const Nothing) (toList [1, 2, 3])) == (toList [2, 3])
   assert $ (alterAt 1 (const Nothing) (toList [1, 2, 3])) == (toList [1, 3])
 
-  log "reverse should reverse the order of items in an array"
+  log "reverse should reverse the order of items in an list"
   assert $ (reverse (toList [1, 2, 3])) == toList [3, 2, 1]
   assert $ (reverse nil') == nil'
 
-  log "concat should join an array of arrays"
+  log "concat should join an list of lists"
   assert $ (concat (toList [toList [1, 2], toList [3, 4]])) == toList [1, 2, 3, 4]
   assert $ (concat (toList [toList [1], nil'])) == toList [1]
   assert $ (concat (toList [nil', nil'])) == nil'
@@ -163,10 +163,10 @@ testListLazy = do
   -- assert $ filterM (Just <<< odd) (range 0 10) == Just (toList [1, 3, 5, 7, 9])
   -- assert $ filterM (const Nothing) (range 0 10) == Nothing
 
-  log "mapMaybe should transform every item in an array, throwing out Nothing values"
+  log "mapMaybe should transform every item in an list, throwing out Nothing values"
   assert $ mapMaybe (\x -> if x /= 0 then Just x else Nothing) (toList [0, 1, 0, 0, 2, 3]) == toList [1, 2, 3]
 
-  log "catMaybe should take an array of Maybe values and throw out Nothings"
+  log "catMaybe should take an list of Maybe values and throw out Nothings"
   assert $ catMaybes (toList [Nothing, Just 2, Nothing, Just 4]) == toList [2, 4]
 
   -- log "sort should reorder a list into ascending order based on the result of compare"
@@ -175,38 +175,38 @@ testListLazy = do
   -- log "sortBy should reorder a list into ascending order based on the result of a comparison function"
   -- assert $ sortBy (flip compare) (toList [1, 3, 2, 5, 6, 4]) == toList [6, 5, 4, 3, 2, 1]
 
-  log "take should keep the specified number of items from the front of an array, discarding the rest"
+  log "take should keep the specified number of items from the front of an list, discarding the rest"
   assert $ (take 1 (toList [1, 2, 3])) == toList [1]
   assert $ (take 2 (toList [1, 2, 3])) == toList [1, 2]
   assert $ (take 1 nil') == nil'
 
-  log "takeWhile should keep all values that match a predicate from the front of an array"
+  log "takeWhile should keep all values that match a predicate from the front of an list"
   assert $ (takeWhile (/= 2) (toList [1, 2, 3])) == toList [1]
   assert $ (takeWhile (/= 3) (toList [1, 2, 3])) == toList [1, 2]
   assert $ (takeWhile (/= 1) nil') == nil'
 
-  log "drop should remove the specified number of items from the front of an array"
+  log "drop should remove the specified number of items from the front of an list"
   assert $ (drop 1 (toList [1, 2, 3])) == toList [2, 3]
   assert $ (drop 2 (toList [1, 2, 3])) == toList [3]
   assert $ (drop 1 nil') == nil'
 
-  log "dropWhile should remove all values that match a predicate from the front of an array"
+  log "dropWhile should remove all values that match a predicate from the front of an list"
   assert $ (dropWhile (/= 1) (toList [1, 2, 3])) == toList [1, 2, 3]
   assert $ (dropWhile (/= 2) (toList [1, 2, 3])) == toList [2, 3]
   assert $ (dropWhile (/= 1) nil') == nil'
 
-  log "span should split an array in two based on a predicate"
+  log "span should split an list in two based on a predicate"
   let spanResult = span (< 4) (toList [1, 2, 3, 4, 5, 6, 7])
   assert $ spanResult.init == toList [1, 2, 3]
   assert $ spanResult.rest == toList [4, 5, 6, 7]
 
-  log "group should group consecutive equal elements into arrays"
+  log "group should group consecutive equal elements into lists"
   assert $ group (toList [1, 2, 2, 3, 3, 3, 1]) == toList [toList [1], toList [2, 2], toList [3, 3, 3], toList [1]]
 
-  -- log "group' should sort then group consecutive equal elements into arrays"
+  -- log "group' should sort then group consecutive equal elements into lists"
   -- assert $ group' (toList [1, 2, 2, 3, 3, 3, 1]) == toList [toList [1, 1], toList [2, 2], toList [3, 3, 3]]
 
-  log "groupBy should group consecutive equal elements into arrays based on an equivalence relation"
+  log "groupBy should group consecutive equal elements into lists based on an equivalence relation"
   assert $ groupBy (\x y -> odd x && odd y) (toList [1, 1, 2, 2, 3, 3]) == toList [toList [1, 1], toList [2], toList [2], toList [3, 3]]
 
   log "nub should remove duplicate items from the list"
@@ -216,28 +216,28 @@ testListLazy = do
   let nubPred = \x y -> if odd x then false else x == y
   assert $ nubBy nubPred (toList [1, 2, 2, 3, 3, 4, 4, 1]) == toList [1, 2, 3, 3, 4, 1]
 
-  log "union should produce the union of two arrays"
+  log "union should produce the union of two lists"
   assert $ union (toList [1, 2, 3]) (toList [2, 3, 4]) == toList [1, 2, 3, 4]
   assert $ union (toList [1, 1, 2, 3]) (toList [2, 3, 4]) == toList [1, 1, 2, 3, 4]
 
-  log "unionBy should produce the union of two arrays using the specified equality relation"
+  log "unionBy should produce the union of two lists using the specified equality relation"
   assert $ unionBy (\_ y -> y < 5) (toList [1, 2, 3]) (toList [2, 3, 4, 5, 6]) == toList [1, 2, 3, 5, 6]
 
-  log "delete should remove the first matching item from an array"
+  log "delete should remove the first matching item from an list"
   assert $ delete 1 (toList [1, 2, 1]) == toList [2, 1]
   assert $ delete 2 (toList [1, 2, 1]) == toList [1, 1]
 
-  log "deleteBy should remove the first equality-relation-matching item from an array"
+  log "deleteBy should remove the first equality-relation-matching item from an list"
   assert $ deleteBy (/=) 2 (toList [1, 2, 1]) == toList [2, 1]
   assert $ deleteBy (/=) 1 (toList [1, 2, 1]) == toList [1, 1]
 
   log "(\\\\) should return the difference between two lists"
   assert $ toList [1, 2, 3, 4, 3, 2, 1] \\ toList [1, 1, 2, 3] == toList [4, 3, 2]
 
-  log "intersect should return the intersection of two arrays"
+  log "intersect should return the intersection of two lists"
   assert $ intersect (toList [1, 2, 3, 4, 3, 2, 1]) (toList [1, 1, 2, 3]) == toList [1, 2, 3, 3, 2, 1]
 
-  log "intersectBy should return the intersection of two arrays using the specified equivalence relation"
+  log "intersectBy should return the intersection of two lists using the specified equivalence relation"
   assert $ intersectBy (\x y -> (x * 2) == y) (toList [1, 2, 3]) (toList [2, 6]) == toList [1, 3]
 
   log "zipWith should use the specified function to zip two lists together"

--- a/test/Test/Data/List/Unsafe.purs
+++ b/test/Test/Data/List/Unsafe.purs
@@ -1,0 +1,34 @@
+module Test.Data.List.Unsafe (testListUnsafe) where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+import Data.List (List(..), toList)
+import Data.List.Unsafe
+import Data.Maybe (Maybe(..))
+import Test.Assert (assert, assertThrows)
+
+testListUnsafe = do
+
+  log "head should return a Just-wrapped first value of a non-empty list"
+  assert $ head (toList ["foo", "bar"]) == "foo"
+
+  log "head should throw an error for an empty list"
+  assertThrows \_ -> head Nil
+
+  log "last should return a Just-wrapped last value of a non-empty list"
+  assert $ last (toList ["foo", "bar"]) == "bar"
+
+  log "last should throw an error for an empty list"
+  assertThrows \_ -> last Nil
+
+  log "tail should return a Just-wrapped list containing all the items in an list apart from the first for a non-empty list"
+  assert $ tail (toList ["foo", "bar", "baz"]) == toList ["bar", "baz"]
+
+  log "tail should throw an error for an empty list"
+  assertThrows \_ -> tail Nil
+
+  log "init should return a Just-wrapped list containing all the items in an list apart from the first for a non-empty list"
+  assert $ init (toList ["foo", "bar", "baz"]) == toList ["foo", "bar"]
+
+  log "init should throw an error for an empty list"
+  assertThrows \_ -> init Nil

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -3,7 +3,9 @@ module Test.Main where
 import Prelude
 import Test.Data.List
 import Test.Data.List.Lazy
+import Test.Data.List.Unsafe
 
 main = do
   testList
   testListLazy
+  testListUnsafe


### PR DESCRIPTION
`unsafeThrow` is a bit dodgy, but getting meaningful errors from unsafe failures may be worthwhile? I think we do that in the unsafe FFI in some other places.