### PR TITLE
Make functions in Data.List stack-safe

### DIFF
--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -185,8 +185,7 @@ null _ = false
 -- |
 -- | Running time: `O(n)`
 length :: forall a. List a -> Int
-length Nil = 0
-length (Cons _ xs) = 1 + length xs
+length = foldl (\acc _ -> acc + 1) 0
 
 --------------------------------------------------------------------------------
 -- Extending arrays ------------------------------------------------------------
@@ -712,10 +711,10 @@ instance functorList :: Functor List where
 instance foldableList :: Foldable List where
   foldr _ b Nil = b
   foldr o b (Cons a as) = a `o` foldr o b as
-  foldl _ b Nil = b
-  foldl o b (Cons a as) = foldl o (b `o` a) as
-  foldMap _ Nil = mempty
-  foldMap f (Cons x xs) = f x <> foldMap f xs
+  foldl = go
+    where go _ b Nil = b
+          go o b (Cons a as) = go o (b `o` a) as
+  foldMap f = foldl (\acc -> append acc <<< f) mempty
 
 instance unfoldableList :: Unfoldable List where
   unfoldr f b = go (f b)

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -712,6 +712,7 @@ instance foldableList :: Foldable List where
   foldr _ b Nil = b
   foldr o b (Cons a as) = a `o` foldr o b as
   foldl = go
+    -- FIXME: Helper function is needed until purescript/purescript#1413 is fixed
     where go _ b Nil = b
           go o b (Cons a as) = go o (b `o` a) as
   foldMap f = foldl (\acc -> append acc <<< f) mempty

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -1,7 +1,10 @@
 module Test.Data.List (testList) where
 
 import Prelude
+import Control.Monad
 import Control.Monad.Eff.Console (log)
+import Data.Foldable
+import Data.Monoid.Additive
 import Data.List
 import Data.Maybe (Maybe(..), isNothing)
 import Data.Maybe.Unsafe (fromJust)
@@ -45,6 +48,9 @@ testList = do
   assert $ length nil == 0
   assert $ length (toList [1]) == 1
   assert $ length (toList [1, 2, 3, 4, 5]) == 5
+
+  log "length should be stack-safe"
+  void $ pure $ length (range 1 100000)
 
   log "snoc should add an item to the end of an list"
   assert $ toList [1, 2, 3] `snoc` 4 == toList [1, 2, 3, 4]
@@ -270,6 +276,12 @@ testList = do
   log "foldM should perform a fold using a monadic step function"
   assert $ foldM (\x y -> Just (x + y)) 0 (range 1 10) == Just 55
   assert $ foldM (\_ _ -> Nothing) 0 (range 1 10) == Nothing
+
+  log "foldl should be stack-safe"
+  void $ pure $ foldl (+) 0 $ range 1 100000
+
+  log "foldMap should be stack-safe"
+  void $ pure $ foldMap Additive $ range 1 100000
 
   -- log "can find the first 10 primes using lazy lists"
   -- let eratos :: L.List Number -> L.List Number

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -283,6 +283,9 @@ testList = do
   log "foldMap should be stack-safe"
   void $ pure $ foldMap Additive $ range 1 100000
 
+  log "foldMap should be left-to-right"
+  assert $ foldMap show (range 1 5) == "12345"
+
   -- log "can find the first 10 primes using lazy lists"
   -- let eratos :: L.List Number -> L.List Number
   --     eratos xs = Control.Lazy.defer \_ ->


### PR DESCRIPTION
I've noticed, that some of the functions which certainly can be tail recursive aren't, so I've fixed the most obvious. But before going further I thought it would be wise to ask if there is some reason why they weren't tail recursive before?