### PR TITLE
Import Data.Unfoldable explicitly to avoid name collision

### DIFF
--- a/docs/Data/List.md
+++ b/docs/Data/List.md
@@ -536,17 +536,14 @@ Running time: `O(n)`
 nub :: forall a. (Eq a) => List a -> List a
 ```
 
-Special case of `nubBy`: `nubBy eq`
-
 #### `nubBy`
 
 ``` purescript
 nubBy :: forall a. (a -> a -> Boolean) -> List a -> List a
 ```
 
-Remove duplicate elements from a list, using the specified function to
-determine equality of elements. The first occurence of an element is always
-the one that is kept.
+Remove duplicate elements from a list, using the specified
+function to determine equality of elements.
 
 Running time: `O(n^2)`
 
@@ -664,3 +661,5 @@ second components.
 ``` purescript
 foldM :: forall m a b. (Monad m) => (a -> b -> m a) -> a -> List b -> m a
 ```
+
+

--- a/docs/Data/List/Lazy.md
+++ b/docs/Data/List/Lazy.md
@@ -482,17 +482,14 @@ Running time: `O(n)`
 nub :: forall a. (Eq a) => List a -> List a
 ```
 
-Special case of `nubBy`: `nubBy eq`
-
 #### `nubBy`
 
 ``` purescript
 nubBy :: forall a. (a -> a -> Boolean) -> List a -> List a
 ```
 
-Remove duplicate elements from a list, using the specified function to
-determine equality of elements. The first occurence of an element is always
-the one that is kept.
+Remove duplicate elements from a list, using the specified
+function to determine equality of elements.
 
 Running time: `O(n^2)`
 
@@ -586,3 +583,5 @@ zip :: forall a b. List a -> List b -> List (Tuple a b)
 Collect pairs of elements at the same positions in two lists.
 
 Running time: `O(min(m, n))`
+
+

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -89,7 +89,7 @@ import Data.Maybe
 import Data.Tuple (Tuple(..))
 import Data.Monoid
 import Data.Foldable
-import Data.Unfoldable
+import Data.Unfoldable (Unfoldable, unfoldr)
 import Data.Traversable
 
 import Control.Alt

--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -102,7 +102,7 @@ import Data.Maybe
 import Data.Monoid
 import Data.Traversable
 import Data.Tuple (Tuple(..), fst, snd)
-import Data.Unfoldable
+import Data.Unfoldable (Unfoldable, unfoldr)
 
 import qualified Control.Lazy as Z
 


### PR DESCRIPTION
Fixes https://github.com/purescript/purescript-lists/issues/48