### PR TITLE
suppress psc 0.8.4 warning

### DIFF
--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -302,7 +302,7 @@ findIndex fn = go 0
 
 -- | Find the last index for which a predicate holds.
 findLastIndex :: forall a. (a -> Boolean) -> List a -> Maybe Int
-findLastIndex fn xs = ((length xs - 1) -) <$> findIndex fn (reverse xs)
+findLastIndex fn xs = ((length xs - 1) - _) <$> findIndex fn (reverse xs)
 
 -- | Insert an element into a list at the specified index, returning a new
 -- | list or `Nothing` if the index is out-of-bounds.


### PR DESCRIPTION
```
in module Data.List
at .../purescript-lists/src/Data/List.purs line 305, column 1 - line 311, column 1

  An operator section uses legacy syntax. Operator sections are now written using anonymous function syntax:

    ((length xs - 1) - _)

  Support for legacy operator sections will be removed in PureScript 0.9.

in value declaration findLastIndex

See https://github.com/purescript/purescript/wiki/Error-Code-DeprecatedOperatorSection for more information,
or to contribute content related to this warning.
```