### PR TITLE
Avoid using operators for binding arguments

### DIFF
--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -582,7 +582,7 @@ nub = nubBy eq
 -- | Running time: `O(n^2)`
 nubBy :: forall a. (a -> a -> Boolean) -> List a -> List a
 nubBy _     Nil = Nil
-nubBy (==) (Cons x xs) = Cons x (nubBy (==) (filter (\y -> not (x == y)) xs))
+nubBy eq' (Cons x xs) = Cons x (nubBy eq' (filter (\y -> not (eq' x y)) xs))
 
 -- | Calculate the union of two lists.
 -- |
@@ -609,8 +609,8 @@ delete = deleteBy (==)
 -- | Running time: `O(n)`
 deleteBy :: forall a. (a -> a -> Boolean) -> a -> List a -> List a
 deleteBy _ _ Nil = Nil
-deleteBy (==) x (Cons y ys) | x == y = ys
-deleteBy (==) x (Cons y ys) = Cons y (deleteBy (==) x ys)
+deleteBy eq' x (Cons y ys) | eq' x y = ys
+deleteBy eq' x (Cons y ys) = Cons y (deleteBy eq' x ys)
 
 infix 5 difference as \\
 


### PR DESCRIPTION
It seems the compiler as of the current master (4852b5d) is no longer able to bind operators as function arguments. If this is intentional, should it be listed in https://github.com/purescript/purescript/issues/2012?