### PR TITLE
Use NonEmptyList for lazy version of group functions

### DIFF
--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -94,10 +94,12 @@ import Prelude
 import Control.Lazy as Z
 
 import Data.Foldable (class Foldable, foldr, any, foldl)
+import Data.Lazy (defer)
 import Data.List.Lazy.Types (List(..), Step(..), step, nil, cons, (:))
+import Data.List.Lazy.Types (NonEmptyList(..)) as NEL
 import Data.Maybe (Maybe(..), isNothing)
 import Data.Newtype (unwrap)
-import Data.NonEmpty (NonEmpty, (:|))
+import Data.NonEmpty ((:|))
 import Data.Traversable (sequence)
 import Data.Tuple (Tuple(..))
 import Data.Unfoldable (class Unfoldable, unfoldr)
@@ -527,20 +529,21 @@ span p xs =
 -- | ```
 -- |
 -- | Running time: `O(n)`
-group :: forall a. Eq a => List a -> List (NonEmpty List a)
+group :: forall a. Eq a => List a -> List (NEL.NonEmptyList a)
 group = groupBy (==)
 
 -- | Group equal, consecutive elements of a list into lists, using the specified
 -- | equivalence relation to determine equality.
 -- |
 -- | Running time: `O(n)`
-groupBy :: forall a. (a -> a -> Boolean) -> List a -> List (NonEmpty List a)
+groupBy :: forall a. (a -> a -> Boolean) -> List a -> List (NEL.NonEmptyList a)
 groupBy eq xs = List (go <$> unwrap xs)
   where
   go Nil = Nil
   go (Cons x xs) =
     case span (eq x) xs of
-      { init: ys, rest: zs } -> Cons (x :| ys) (groupBy eq zs)
+      { init: ys, rest: zs } ->
+        Cons (NEL.NonEmptyList (defer \_ -> x :| ys)) (groupBy eq zs)
 
 --------------------------------------------------------------------------------
 -- Set-like operations ---------------------------------------------------------

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -6,10 +6,11 @@ import Control.Lazy (defer)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
 
+import Data.Lazy as Z
 import Data.List.Lazy (List, nil, cons, singleton, transpose, take, iterate, filter, uncons, foldM, range, unzip, zip, length, zipWithA, replicate, repeat, zipWith, intersectBy, intersect, deleteBy, delete, unionBy, union, nubBy, nub, groupBy, group, span, dropWhile, drop, takeWhile, slice, catMaybes, mapMaybe, filterM, concat, concatMap, reverse, alterAt, modifyAt, updateAt, deleteAt, insertAt, findLastIndex, findIndex, elemLastIndex, elemIndex, init, tail, last, head, insertBy, insert, snoc, null, replicateM, fromFoldable, (:), (\\), (!!))
+import Data.List.Lazy.NonEmpty as NEL
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.NonEmpty ((:|))
-import Data.NonEmpty as NE
 import Data.Tuple (Tuple(..))
 
 import Partial.Unsafe (unsafePartial)
@@ -18,7 +19,9 @@ import Test.Assert (ASSERT, assert)
 
 testListLazy :: forall eff. Eff (assert :: ASSERT, console :: CONSOLE | eff) Unit
 testListLazy = do
-  let l = fromFoldable
+  let
+    l = fromFoldable
+    nel xxs = NEL.NonEmptyList (Z.defer \_ -> xxs)
 
   log "singleton should construct an list with a single value"
   assert $ singleton 1 == l [1]
@@ -223,13 +226,13 @@ testListLazy = do
   assert $ spanResult.rest == l [4, 5, 6, 7]
 
   log "group should group consecutive equal elements into lists"
-  assert $ group (l [1, 2, 2, 3, 3, 3, 1]) == l [NE.singleton 1, 2 :| l [2], 3 :| l [3, 3], NE.singleton 1]
+  assert $ group (l [1, 2, 2, 3, 3, 3, 1]) == l [NEL.singleton 1, nel (2 :| l [2]), nel (3 :| l [3, 3]), NEL.singleton 1]
 
   -- log "group' should sort then group consecutive equal elements into lists"
   -- assert $ group' (l [1, 2, 2, 3, 3, 3, 1]) == l [l [1, 1], l [2, 2], l [3, 3, 3]]
 
   log "groupBy should group consecutive equal elements into lists based on an equivalence relation"
-  assert $ groupBy (\x y -> odd x && odd y) (l [1, 1, 2, 2, 3, 3]) == l [1 :| l [1], NE.singleton 2, NE.singleton 2, 3 :| l [3]]
+  assert $ groupBy (\x y -> odd x && odd y) (l [1, 1, 2, 2, 3, 3]) == l [nel (1 :| l [1]), NEL.singleton 2, NEL.singleton 2, nel (3 :| l [3])]
 
   log "nub should remove duplicate elements from the list, keeping the first occurence"
   assert $ nub (l [1, 2, 2, 3, 4, 1]) == l [1, 2, 3, 4]


### PR DESCRIPTION
Nearly made a stupid mistake there... deleted the v3 release immediately after tagging it, so will re-release as that once this is in.