### PR TITLE
Make `append` stack-safe

### DIFF
--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -50,8 +50,7 @@ instance ordList :: Ord a => Ord (List a) where
         other -> other
 
 instance semigroupList :: Semigroup (List a) where
-  append Nil ys = ys
-  append (x : xs) ys = x : (xs <> ys)
+  append xs ys = foldr (:) ys xs
 
 instance monoidList :: Monoid (List a) where
   mempty = Nil

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -319,6 +319,13 @@ testList = do
   let xs = fromFoldable (range 1 100000)
   assert $ traverse Just xs == Just xs
 
+  log "append should concatenate two lists"
+  assert $ (l [1, 2]) <> (l [3, 4]) == (l [1, 2, 3, 4])
+
+  log "append should be stack-safe"
+  void $ pure $ xs <> xs
+
+
 step :: Int -> Maybe (Tuple Int Int)
 step 6 = Nothing
 step n = Just (Tuple n (n + 1))


### PR DESCRIPTION
Re-implement `append` in terms of `foldr` to avoid
"RangeError: Maximum call stack size exceeded" errors.
Add tests for functionality and stack-safety.