### PR TITLE
appendList function for nonempty lists

### DIFF
--- a/src/Data/List/Lazy/NonEmpty.purs
+++ b/src/Data/List/Lazy/NonEmpty.purs
@@ -68,5 +68,5 @@ length (NonEmptyList nel) = case force nel of x :| xs -> 1 + L.length xs
 concatMap :: forall a b. (a -> NonEmptyList b) -> NonEmptyList a -> NonEmptyList b
 concatMap = flip bind
 
-appendList :: NonEmptyList ~> L.List ~> NonEmptyList
-appendList (NonEmptyList (x :| xs)) ys = NonEmptyList (x :| (xs <> ys))
+appendList :: forall a. NonEmptyList a -> L.List a -> NonEmptyList a
+appendList nel ys = NonEmptyList (defer \_ -> ((head nel) :| (tail nel) <> ys))

--- a/src/Data/List/Lazy/NonEmpty.purs
+++ b/src/Data/List/Lazy/NonEmpty.purs
@@ -11,6 +11,7 @@ module Data.List.Lazy.NonEmpty
   , uncons
   , length
   , concatMap
+  , appendFoldable
   ) where
 
 import Prelude
@@ -68,5 +69,6 @@ length (NonEmptyList nel) = case force nel of x :| xs -> 1 + L.length xs
 concatMap :: forall a b. (a -> NonEmptyList b) -> NonEmptyList a -> NonEmptyList b
 concatMap = flip bind
 
-appendList :: forall a. NonEmptyList a -> L.List a -> NonEmptyList a
-appendList nel ys = NonEmptyList (defer \_ -> head nel :| tail nel <> ys)
+appendFoldable :: forall t a. Foldable t => NonEmptyList a -> t a -> NonEmptyList a
+appendFoldable nel ys =
+  NonEmptyList (defer \_ -> head nel :| tail nel <> L.fromFoldable ys)

--- a/src/Data/List/Lazy/NonEmpty.purs
+++ b/src/Data/List/Lazy/NonEmpty.purs
@@ -67,3 +67,6 @@ length (NonEmptyList nel) = case force nel of x :| xs -> 1 + L.length xs
 
 concatMap :: forall a b. (a -> NonEmptyList b) -> NonEmptyList a -> NonEmptyList b
 concatMap = flip bind
+
+appendList :: NonEmptyList ~> L.List ~> NonEmptyList
+appendList (NonEmptyList (x :| xs)) ys = NonEmptyList (x :| (xs <> ys))

--- a/src/Data/List/Lazy/NonEmpty.purs
+++ b/src/Data/List/Lazy/NonEmpty.purs
@@ -69,4 +69,4 @@ concatMap :: forall a b. (a -> NonEmptyList b) -> NonEmptyList a -> NonEmptyList
 concatMap = flip bind
 
 appendList :: forall a. NonEmptyList a -> L.List a -> NonEmptyList a
-appendList nel ys = NonEmptyList (defer \_ -> ((head nel) :| (tail nel) <> ys))
+appendList nel ys = NonEmptyList (defer \_ -> head nel :| tail nel <> ys)

--- a/src/Data/List/NonEmpty.purs
+++ b/src/Data/List/NonEmpty.purs
@@ -11,6 +11,7 @@ module Data.List.NonEmpty
   , uncons
   , length
   , concatMap
+  , appendFoldable
   ) where
 
 import Prelude
@@ -63,5 +64,6 @@ length (NonEmptyList (x :| xs)) = 1 + L.length xs
 concatMap :: forall a b. (a -> NonEmptyList b) -> NonEmptyList a -> NonEmptyList b
 concatMap = flip bind
 
-appendList :: forall a. NonEmptyList a -> L.List a -> NonEmptyList a
-appendList (NonEmptyList (x :| xs)) ys = NonEmptyList (x :| (xs <> ys))
+appendFoldable :: forall t a. Foldable t => NonEmptyList a -> t a -> NonEmptyList a
+appendFoldable (NonEmptyList (x :| xs)) ys =
+  NonEmptyList (x :| (xs <> L.fromFoldable ys))

--- a/src/Data/List/NonEmpty.purs
+++ b/src/Data/List/NonEmpty.purs
@@ -63,5 +63,5 @@ length (NonEmptyList (x :| xs)) = 1 + L.length xs
 concatMap :: forall a b. (a -> NonEmptyList b) -> NonEmptyList a -> NonEmptyList b
 concatMap = flip bind
 
-appendList :: NonEmptyList ~> L.List ~> NonEmptyList
+appendList :: forall a. NonEmptyList a -> L.List a -> NonEmptyList a
 appendList (NonEmptyList (x :| xs)) ys = NonEmptyList (x :| (xs <> ys))

--- a/src/Data/List/NonEmpty.purs
+++ b/src/Data/List/NonEmpty.purs
@@ -62,3 +62,6 @@ length (NonEmptyList (x :| xs)) = 1 + L.length xs
 
 concatMap :: forall a b. (a -> NonEmptyList b) -> NonEmptyList a -> NonEmptyList b
 concatMap = flip bind
+
+appendList :: NonEmptyList ~> L.List ~> NonEmptyList
+appendList (NonEmptyList (x :| xs)) ys = NonEmptyList (x :| (xs <> ys))


### PR DESCRIPTION
For both strict and lazy nonempty lists, a function
appendList :: NonEmptyList ~> List ~> NonEmptyList

(a very handy function for creating an Arbitrary instance for NonEmptyLists).