### PR TITLE
Require foldable-traversable ^3.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "purescript-nonempty": "^4.0.0",
     "purescript-tailrec": "^3.3.0",
     "purescript-unfoldable": "^3.0.0",
-    "purescript-partial": "^1.0.0"
+    "purescript-partial": "^1.0.0",
+    "purescript-foldable-traversable": "^3.3.0"
   },
   "devDependencies": {
     "purescript-arrays": "^4.0.0",


### PR DESCRIPTION
foldable-traversable@3.3.0 is the first release that includes `Traversable1` et al. that was added to this library in a recent release, so we need to make sure that at least that version is required. (None of the dependencies require more than ^3.0.0.)