### PR TITLE
Avoid infinite loop possibility with takeEnd

### DIFF
--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -517,7 +517,7 @@ slice start end xs = take (end - start) (drop start xs)
 take :: forall a. Int -> List a -> List a
 take = go Nil
   where
-  go acc 0 _ = reverse acc
+  go acc n _ | n < 1 = reverse acc
   go acc _ Nil = reverse acc
   go acc n (x : xs) = go (x : acc) (n - 1) xs
 

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -541,7 +541,7 @@ takeWhile p = go Nil
 -- |
 -- | Running time: `O(n)` where `n` is the number of elements to drop.
 drop :: forall a. Int -> List a -> List a
-drop 0 xs = xs
+drop n xs | n < 1 = xs
 drop _ Nil = Nil
 drop n (x : xs) = drop (n - 1) xs
 

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -230,16 +230,18 @@ testList = do
   assert $ (takeEnd 1 (l [1, 2, 3])) == l [3]
   assert $ (takeEnd 2 (l [1, 2, 3])) == l [2, 3]
   assert $ (takeEnd 1 nil) == nil
+  assert $ (takeEnd 2 (l [1])) == l [1]
 
   log "takeWhile should keep all values that match a predicate from the front of an list"
   assert $ (takeWhile (_ /= 2) (l [1, 2, 3])) == l [1]
   assert $ (takeWhile (_ /= 3) (l [1, 2, 3])) == l [1, 2]
   assert $ (takeWhile (_ /= 1) nil) == nil
 
-  log "dropE should remove the specified number of items from the front of an list"
+  log "drop should remove the specified number of items from the front of an list"
   assert $ (drop 1 (l [1, 2, 3])) == l [2, 3]
   assert $ (drop 2 (l [1, 2, 3])) == l [3]
   assert $ (drop 1 nil) == nil
+  assert $ (drop (-1) (l [1, 2, 3])) == l [1, 2, 3]
 
   log "dropEnd should remove the specified number of items from the end of an list"
   assert $ (dropEnd 1 (l [1, 2, 3])) == l [1, 2]

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -225,6 +225,8 @@ testList = do
   assert $ (take 1 (l [1, 2, 3])) == l [1]
   assert $ (take 2 (l [1, 2, 3])) == l [1, 2]
   assert $ (take 1 nil) == nil
+  assert $ (take 0 (l [1, 2])) == l []
+  assert $ (take (-1) (l [1, 2])) == l []
 
   log "takeEnd should keep the specified number of items from the end of an list, discarding the rest"
   assert $ (takeEnd 1 (l [1, 2, 3])) == l [3]


### PR DESCRIPTION
Calling `takeEnd` with an `Int` value greater than the length of the list currently leads to an infinite loop. I added a couple test cases to demonstrate this and added a guard in `drop` against negative Ints.