### PR TITLE
List Functor: mix unrolled and reverse map

### DIFF
--- a/bench/Bench/Data/List.purs
+++ b/bench/Bench/Data/List.purs
@@ -1,0 +1,48 @@
+module Bench.Data.List where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+import Performance.Minibench (bench)
+
+import Data.List as L
+
+benchList :: Eff (console :: CONSOLE) Unit
+benchList = do
+  log "map"
+  log "---"
+  benchMap
+
+  where
+
+  benchMap = do
+    let nats = L.range 0 999999
+        mapFn = map (_ + 1)
+        list1000    = L.take 1000 nats
+        list2000    = L.take 2000 nats
+        list5000    = L.take 5000 nats
+        list10000   = L.take 10000 nats
+        list100000  = L.take 100000 nats
+
+    log "map: empty list"
+    let emptyList = L.Nil
+    bench \_ -> mapFn emptyList
+
+    log "map: singleton list"
+    let singletonList = L.Cons 0 L.Nil
+    bench \_ -> mapFn singletonList
+
+    log $ "map: list (" <> show (L.length list1000) <> " elems)"
+    bench \_ -> mapFn list1000
+
+    log $ "map: list (" <> show (L.length list2000) <> " elems)"
+    bench \_ -> mapFn list2000
+
+    log $ "map: list (" <> show (L.length list5000) <> " elems)"
+    bench \_ -> mapFn list5000
+
+    log $ "map: list (" <> show (L.length list10000) <> " elems)"
+    bench \_ -> mapFn list10000
+
+    log $ "map: list (" <> show (L.length list100000) <> " elems)"
+    bench \_ -> mapFn list100000

--- a/bench/Main.purs
+++ b/bench/Main.purs
@@ -1,0 +1,13 @@
+module Bench.Main where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+
+import Bench.Data.List (benchList)
+
+main :: Eff (console :: CONSOLE) Unit
+main = do
+  log "List"
+  log "===="
+  benchList

--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,7 @@
     "purescript-arrays": "^4.0.0",
     "purescript-assert": "^3.0.0",
     "purescript-console": "^3.0.0",
-    "purescript-math": "^2.0.0"
+    "purescript-math": "^2.0.0",
+    "purescript-minibench": "matthewleon/purescript-minibench#gc"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,6 @@
     "purescript-assert": "^3.0.0",
     "purescript-console": "^3.0.0",
     "purescript-math": "^2.0.0",
-    "purescript-minibench": "matthewleon/purescript-minibench#gc"
+    "purescript-minibench": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
     "build": "pulp build -- --censor-lib --strict",
-    "test": "pulp test"
+    "test": "pulp test",
+
+    "bench:build": "purs compile 'bench/**/*.purs' 'src/**/*.purs' 'bower_components/*/src/**/*.purs'",
+    "bench:run": "node --expose-gc -e 'require(\"./output/Bench.Main/index.js\").main()'",
+    "bench": "npm run bench:build && npm run bench:run"
   },
   "devDependencies": {
     "pulp": "^11.0.0",

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -79,33 +79,18 @@ instance functorList :: Functor List where
 -- https://discuss.ocaml.org/t/a-new-list-map-that-is-both-stack-safe-and-fast/865
 -- chunk sizes determined through experimentation
 listMap :: forall a b. (a -> b) -> List a -> List b
-listMap f = startUnrolledMap unrollLimit where
-  -- iterate the unrolled map up to 200 times,
-  -- which hits up to 1000 elements
-  unrollLimit = 200
-
-  startUnrolledMap :: Int -> List a -> List b
-  startUnrolledMap 0 (x : xs) = f x : chunkedRevMap xs
-  startUnrolledMap n (x1 : x2 : x3 : x4 : x5 : xs) =
-    f x1 : f x2 : f x3 : f x4 : f x5 : startUnrolledMap (n - 1) xs
-  startUnrolledMap n (x1 : x2 : x3 : x4 : xs) =
-    f x1 : f x2 : f x3 : f x4 : startUnrolledMap (n - 1) xs
-  startUnrolledMap n (x1 : x2 : x3 : xs) =
-    f x1 : f x2 : f x3 : startUnrolledMap (n - 1) xs
-  startUnrolledMap n (x1 : x2 : xs) =
-    f x1 : f x2 : startUnrolledMap (n - 1) xs
-  startUnrolledMap n (x : xs) = f x : startUnrolledMap (n - 1) xs
-
-  startUnrolledMap _ Nil = Nil
-
-  chunkedRevMap :: List a -> List b
-  chunkedRevMap = go Nil
+listMap f = chunkedRevMap Nil
+  where
+  chunkedRevMap :: List (List a) -> List a -> List b
+  chunkedRevMap chunksAcc chunk@(x1 : x2 : x3 : xs) =
+    chunkedRevMap (chunk : chunksAcc) xs
+  chunkedRevMap chunksAcc xs =
+    reverseUnrolledMap chunksAcc $ unrolledMap xs
     where
-    go :: List (List a) -> List a -> List b
-    go chunksAcc chunk@(x1 : x2 : x3 : xs) =
-      go (chunk : chunksAcc) xs
-    go chunksAcc finalChunk =
-      reverseUnrolledMap chunksAcc $ startUnrolledMap 0 finalChunk
+    unrolledMap :: List a -> List b
+    unrolledMap (x1 : x2 : Nil) = f x1 : f x2 : Nil
+    unrolledMap (x1 : Nil) = f x1 : Nil
+    unrolledMap _ = Nil
 
     reverseUnrolledMap :: List (List a) -> List b -> List b
     reverseUnrolledMap ((x1 : x2 : x3 : _) : cs) acc =

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -2,6 +2,8 @@ module Data.List.Types
   ( List(..)
   , (:)
   , NonEmptyList(..)
+  , toList
+  , nelCons
   ) where
 
 import Prelude

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -102,7 +102,7 @@ listMap f = startUnrolledMap unrollLimit where
   chunkedRevMap = go Nil
     where
     go :: List (List a) -> List a -> List b
-    go chunksAcc chunk@(x1 : x2 : x3 : x4 : x5 : xs) =
+    go chunksAcc chunk@(x1 : x2 : x3 : xs) =
       go (chunk : chunksAcc) xs
     go chunksAcc finalChunk =
       reverseUnrolledMap chunksAcc $ startUnrolledMap 0 finalChunk

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -77,8 +77,7 @@ instance functorList :: Functor List where
 -- https://discuss.ocaml.org/t/a-new-list-map-that-is-both-stack-safe-and-fast/865
 -- chunk sizes determined through experimentation
 listMap :: forall a b. (a -> b) -> List a -> List b
-listMap f = startUnrolledMap unrollLimit
-  where
+listMap f = startUnrolledMap unrollLimit where
   -- iterate the unrolled map up to 1000 times,
   -- which hits up to 5000 elements
   unrollLimit = 1000

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -78,9 +78,9 @@ instance functorList :: Functor List where
 -- chunk sizes determined through experimentation
 listMap :: forall a b. (a -> b) -> List a -> List b
 listMap f = startUnrolledMap unrollLimit where
-  -- iterate the unrolled map up to 1000 times,
-  -- which hits up to 5000 elements
-  unrollLimit = 1000
+  -- iterate the unrolled map up to 200 times,
+  -- which hits up to 1000 elements
+  unrollLimit = 200
 
   startUnrolledMap :: Int -> List a -> List b
   startUnrolledMap 0 (x : xs) = f x : chunkedRevMap xs

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -360,6 +360,9 @@ testList = do
   log "map should maintain order"
   assert $ (1..5) == map id (1..5)
 
+  log "map should be stack-safe"
+  void $ pure $ map id (1..100000)
+
   log "transpose"
   assert $ transpose (l [l [1,2,3], l[4,5,6], l [7,8,9]]) ==
                      (l [l [1,4,7], l[2,5,8], l [3,6,9]])

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -363,6 +363,9 @@ testList = do
   log "map should be stack-safe"
   void $ pure $ map id (1..100000)
 
+  log "map should be correct"
+  assert $ (1..1000000) == map (_ + 1) (0..999999)
+
   log "transpose"
   assert $ transpose (l [l [1,2,3], l[4,5,6], l [7,8,9]]) ==
                      (l [l [1,4,7], l[2,5,8], l [3,6,9]])


### PR DESCRIPTION
Addresses #131

The relevant chunk sizes (5 for the initial list segment), (3 for the
tail-recursive remainder) were arrived at through benchmarked
experimentation, mapping a simple (_ + 1) through lists of various
sizes.

Relevant figures:
list of 1000 elems:   142.61 μs -> 36.97 μs
list of 2000 elems:   275.17 μs -> 55.33 μs
list of 10000 elems:  912.73 μs -> 208.39 μs
list of 100000 elems: 34.56 ms  -> 1.24 ms

The ~30x speed increase for long lists is probably explained by the lack
of GC thrashing with this approach.