### PR TITLE
Don't force more than necessary in Data.List.Lazy take

### DIFF
--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -509,8 +509,9 @@ slice start end xs = take (end - start) (drop start xs)
 -- |
 -- | Running time: `O(n)` where `n` is the number of elements to take.
 take :: forall a. Int -> List a -> List a
-take n _ | n <= 0 = nil
-take n xs = List <<< map (go n) <<< unwrap $ xs
+take n = if n <= 0
+  then const nil
+  else List <<< map (go n) <<< unwrap
   where
   go :: Int -> Step a -> Step a
   go _ Nil = Nil

--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -509,10 +509,10 @@ slice start end xs = take (end - start) (drop start xs)
 -- |
 -- | Running time: `O(n)` where `n` is the number of elements to take.
 take :: forall a. Int -> List a -> List a
-take n = List <<< map (go n) <<< unwrap
+take n _ | n <= 0 = nil
+take n xs = List <<< map (go n) <<< unwrap $ xs
   where
   go :: Int -> Step a -> Step a
-  go i _ | i <= 0 = Nil
   go _ Nil = Nil
   go n' (Cons x xs) = Cons x (take (n' - 1) xs)
 

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -272,7 +272,7 @@ testListLazy = do
 
   log "take should evaluate exactly n items which we needed"
   assert let oops x = 0 : (oops x)
-          in (take 1 $ 1 : defer oops) == fromFoldable [1]
+          in (take 1 $ 1 : defer oops) == l [1]
   -- If `take` evaluate more than once, it would crash with a stack overflow
 
   log "takeWhile should keep all values that match a predicate from the front of an list"

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -270,6 +270,11 @@ testListLazy = do
   assert $ (take 2 (l [1, 2, 3])) == l [1, 2]
   assert $ (take 1 nil') == nil'
 
+  log "take should evaluate exactly n items which we needed"
+  assert let oops x = 0 : (oops x)
+          in (take 1 $ 1 : defer oops) == fromFoldable [1]
+  -- If `take` evaluate more than once, it would crash with a stack overflow
+
   log "takeWhile should keep all values that match a predicate from the front of an list"
   assert $ (takeWhile (_ /= 2) (l [1, 2, 3])) == l [1]
   assert $ (takeWhile (_ /= 3) (l [1, 2, 3])) == l [1, 2]

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -271,8 +271,9 @@ testListLazy = do
   assert $ (take 1 nil') == nil'
 
   log "take should evaluate exactly n items which we needed"
-  assert let oops x = 0 : (oops x)
-          in (take 1 $ 1 : defer oops) == l [1]
+  assert let oops x = 0 : oops x
+             xs = 1 : defer oops
+          in take 1 xs == l [1]
   -- If `take` evaluate more than once, it would crash with a stack overflow
 
   log "takeWhile should keep all values that match a predicate from the front of an list"


### PR DESCRIPTION
#138 

Made a fix of `take`.

![fix_take](https://user-images.githubusercontent.com/4210652/34533466-ac7137dc-f0fd-11e7-86de-5451b9c904da.JPG)
