### PR TITLE
Fix Data.List.Lazy iterate

### DIFF
--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -186,7 +186,7 @@ repeat x = Z.fix \xs -> cons x xs
 
 -- | Create a list by iterating a function
 iterate :: forall a. (a -> a) -> a -> List a
-iterate f x = Z.fix \xs -> cons x (f <$> xs)
+iterate f x = cons x (Z.defer \_ -> iterate f (f x))
 
 -- | Create a list by repeating another list
 cycle :: forall a. List a -> List a


### PR DESCRIPTION
A solution of #140 

Here's the result of the modification of `iterate`.
All the values are evaluated exactly once. 

![fix_iterate](https://user-images.githubusercontent.com/4210652/34534427-65696a90-f101-11e7-998f-da17549fc353.JPG)

It still has a bug. Because the result of `take 3 lazyl` should be

```purescript
> take 3 lazyl
1
2
fromStrict ((Cons 0 (Cons 1 (Cons 2 Nil))))
```

Not

```purescript
> take 3 lazyl
1
2
3
fromStrict ((Cons 0 (Cons 1 (Cons 2 Nil))))
```

But the bug is made by `take` (as #138), not `iterate`. So we have nothing to do with this.

Just to be sure, I made a performance comparison between the before and after of `iterate`.
It is made by compiling the purescript code into javascript, and then run the benchmark by Benchmark.js.

Each value in this benchmark is the time of the calculation `sum $ take n $ iterate (_ + 1) 1`, where `n` is the length of list in the benchmark.

The old `iterate` has no value after length > 5000, because it throws exceptions by maximum call stack size exceeded. Yes, it is not stack-safe.

![iterate](https://user-images.githubusercontent.com/4210652/34534549-e51e205a-f101-11e7-856b-1eeb9d5ecadd.png)

The old `iterate` run extremely slow in PSCi (time complexity is not linear), but (I don't know why) it is not bad (except the stack overflow) in this benchmark.

  
  
  
  
  
  