### PR TITLE
Add foldlWhile to List.Lazy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "purescript-bifunctors": "^4.0.0",
     "purescript-control": "^4.0.0",
+    "purescript-either": "^4.0.0",
     "purescript-foldable-traversable": "^4.0.0",
     "purescript-lazy": "^4.0.0",
     "purescript-maybe": "^4.0.0",

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -89,6 +89,7 @@ module Data.List
   , transpose
 
   , foldM
+  , foldlWhile
 
   , module Exports
   ) where
@@ -101,6 +102,7 @@ import Control.Lazy (class Lazy, defer)
 import Control.Monad.Rec.Class (class MonadRec, Step(..), tailRecM, tailRecM2)
 
 import Data.Bifunctor (bimap)
+import Data.Either (Either(..))
 import Data.Foldable (class Foldable, foldr, any, foldl)
 import Data.FunctorWithIndex (mapWithIndex) as FWI
 import Data.List.Types (List(..), (:))
@@ -763,3 +765,11 @@ transpose ((x : xs) : xss) =
 foldM :: forall m a b. Monad m => (a -> b -> m a) -> a -> List b -> m a
 foldM _ a Nil = pure a
 foldM f a (b : bs) = f a b >>= \a' -> foldM f a' bs
+
+-- | Perform a left fold until the list is consumed or the provided function returns a Left value
+foldlWhile :: forall a b. (b -> a -> Either b b) -> b -> List a -> b
+foldlWhile _ acc Nil = acc
+foldlWhile f acc (Cons x xs) =
+  case f acc x of
+    Left acc' -> acc'
+    Right acc' -> foldlWhile f acc' xs

--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -761,14 +761,16 @@ foldrLazy op z = go
 
 -- | Perform a left fold until the list is consumed or the provided function returns a Left value
 foldlWhile :: forall a b. (b -> a -> Either b b) -> b -> List a -> b
-foldlWhile f acc xs = go $ step xs
+foldlWhile f = go
   where
-    go :: Step a -> b
-    go Nil = acc
-    go (Cons x xs') =
-      case f acc x of
-        Left acc' -> acc'
-        Right acc' -> foldlWhile f acc' xs'
+    go :: b -> List a -> b
+    go acc xs =
+      case step xs of
+        Nil -> acc
+        (Cons x xs') ->
+          case f acc x of
+            Left acc' -> acc'
+            Right acc' -> go acc' xs'
 
 -- | Perform a right scan lazily
 scanrLazy :: forall a b. (a -> b -> b) -> b -> List a -> List b

--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -761,16 +761,13 @@ foldrLazy op z = go
 
 -- | Perform a left fold until the list is consumed or the provided function returns a Left value
 foldlWhile :: forall a b. (b -> a -> Either b b) -> b -> List a -> b
-foldlWhile f = go
-  where
-    go :: b -> List a -> b
-    go acc xs =
-      case step xs of
-        Nil -> acc
-        Cons x xs' ->
-          case f acc x of
-            Left acc' -> acc'
-            Right acc' -> go acc' xs'
+foldlWhile f acc xs =
+  case step xs of
+    Nil -> acc
+    Cons x xs' ->
+      case f acc x of
+        Left acc' -> acc'
+        Right acc' -> foldlWhile f acc' xs'
 
 -- | Perform a right scan lazily
 scanrLazy :: forall a b. (a -> b -> b) -> b -> List a -> List b

--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -89,6 +89,7 @@ module Data.List.Lazy
 
   , foldM
   , foldrLazy
+  , foldrWhile
   , scanrLazy
 
   , module Exports
@@ -100,6 +101,7 @@ import Control.Alt ((<|>))
 import Control.Alternative (class Alternative)
 import Control.Lazy as Z
 import Control.Monad.Rec.Class as Rec
+import Data.Either (Either(..))
 import Data.Foldable (class Foldable, foldr, any, foldl)
 import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, elem, notElem, find, findMap, any, all) as Exports
 import Data.Lazy (defer)
@@ -756,6 +758,17 @@ foldrLazy op z = go
     go xs = case step xs of
       Cons x xs' -> Z.defer \_ -> x `op` go xs'
       Nil -> z
+
+-- | Perform a right fold until the list is consumed or the provided function returns a Left value
+foldrWhile :: forall a b. (a -> b -> Either b b) -> b -> List a -> b
+foldrWhile f acc xs = go $ step xs
+  where
+    go :: Step a -> b
+    go Nil = acc
+    go (Cons x xs') =
+      case f x acc of
+        Left acc' -> acc'
+        Right acc' -> foldrWhile f acc' xs'
 
 -- | Perform a right scan lazily
 scanrLazy :: forall a b. (a -> b -> b) -> b -> List a -> List b

--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -89,7 +89,7 @@ module Data.List.Lazy
 
   , foldM
   , foldrLazy
-  , foldrWhile
+  , foldlWhile
   , scanrLazy
 
   , module Exports
@@ -759,16 +759,16 @@ foldrLazy op z = go
       Cons x xs' -> Z.defer \_ -> x `op` go xs'
       Nil -> z
 
--- | Perform a right fold until the list is consumed or the provided function returns a Left value
-foldrWhile :: forall a b. (a -> b -> Either b b) -> b -> List a -> b
-foldrWhile f acc xs = go $ step xs
+-- | Perform a left fold until the list is consumed or the provided function returns a Left value
+foldlWhile :: forall a b. (b -> a -> Either b b) -> b -> List a -> b
+foldlWhile f acc xs = go $ step xs
   where
     go :: Step a -> b
     go Nil = acc
     go (Cons x xs') =
-      case f x acc of
+      case f acc x of
         Left acc' -> acc'
-        Right acc' -> foldrWhile f acc' xs'
+        Right acc' -> foldlWhile f acc' xs'
 
 -- | Perform a right scan lazily
 scanrLazy :: forall a b. (a -> b -> b) -> b -> List a -> List b

--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -767,7 +767,7 @@ foldlWhile f = go
     go acc xs =
       case step xs of
         Nil -> acc
-        (Cons x xs') ->
+        Cons x xs' ->
           case f acc x of
             Left acc' -> acc'
             Right acc' -> go acc' xs'

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -2,9 +2,10 @@ module Test.Data.List (testList) where
 
 import Prelude
 
+import Data.Either (Either(..))
 import Data.Foldable (foldMap, foldl)
 import Data.FoldableWithIndex (foldMapWithIndex, foldlWithIndex, foldrWithIndex)
-import Data.List (List(..), (..), stripPrefix, Pattern(..), length, range, foldM, unzip, zip, zipWithA, zipWith, intersectBy, intersect, (\\), deleteBy, delete, unionBy, union, nubBy, nub, groupBy, group', group, partition, span, dropWhile, drop, dropEnd, takeWhile, take, takeEnd, sortBy, sort, catMaybes, mapMaybe, filterM, filter, concat, concatMap, reverse, alterAt, modifyAt, updateAt, deleteAt, insertAt, findLastIndex, findIndex, elemLastIndex, elemIndex, (!!), uncons, unsnoc, init, tail, last, head, insertBy, insert, snoc, null, singleton, fromFoldable, transpose, mapWithIndex, (:))
+import Data.List (List(..), (..), stripPrefix, Pattern(..), length, range, foldM, foldlWhile, unzip, zip, zipWithA, zipWith, intersectBy, intersect, (\\), deleteBy, delete, unionBy, union, nubBy, nub, groupBy, group', group, partition, span, dropWhile, drop, dropEnd, takeWhile, take, takeEnd, sortBy, sort, catMaybes, mapMaybe, filterM, filter, concat, concatMap, reverse, alterAt, modifyAt, updateAt, deleteAt, insertAt, findLastIndex, findIndex, elemLastIndex, elemIndex, (!!), uncons, unsnoc, init, tail, last, head, insertBy, insert, snoc, null, singleton, fromFoldable, transpose, mapWithIndex, (:))
 import Data.List.NonEmpty as NEL
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Monoid.Additive (Additive(..))
@@ -391,6 +392,16 @@ testList = do
 
   log "append should be stack-safe"
   void $ pure $ xs <> xs
+
+  log "foldlWhile halts when a Left value is returned"
+  assert let ints = fromFoldable (range 1 10)
+             sum = foldlWhile (\acc i -> if i < 5 then Right (i + acc) else Left acc) 0 ints
+          in sum == 10
+
+  log "foldlWhile consumes the whole list if Right values are always returned"
+  assert let ints = fromFoldable (range 1 10)
+             sum = foldlWhile (\acc i -> Right (i + acc)) 0 ints
+          in sum == 55
 
 step :: Int -> Maybe (Tuple Int Int)
 step 6 = Nothing

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -403,6 +403,9 @@ testList = do
              sum = foldlWhile (\acc i -> Right (i + acc)) 0 ints
           in sum == 55
 
+  log "foldlWhile should be stack-safe"
+  void $ pure $ foldlWhile (\acc i -> Right (i + acc)) 0 (range 1 100000)
+
 step :: Int -> Maybe (Tuple Int Int)
 step 6 = Nothing
 step n = Just (Tuple n (n + 1))

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -6,8 +6,9 @@ import Control.Lazy (defer)
 import Data.FoldableWithIndex (foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Lazy as Z
-import Data.List.Lazy (List, Pattern(..), alterAt, catMaybes, concat, concatMap, cons, delete, deleteAt, deleteBy, drop, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, foldMap, foldl, foldr, foldrLazy, fromFoldable, group, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, iterate, last, length, mapMaybe, modifyAt, nil, nub, nubBy, null, partition, range, repeat, replicate, replicateM, reverse, scanrLazy, singleton, slice, snoc, span, stripPrefix, tail, take, takeWhile, transpose, uncons, union, unionBy, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
+import Data.List.Lazy (List, Pattern(..), alterAt, catMaybes, concat, concatMap, cons, delete, deleteAt, deleteBy, drop, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, foldMap, foldl, foldr, foldrLazy, foldrWhile, fromFoldable, group, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, iterate, last, length, mapMaybe, modifyAt, nil, nub, nubBy, null, partition, range, repeat, replicate, replicateM, reverse, scanrLazy, singleton, slice, snoc, span, stripPrefix, tail, take, takeWhile, transpose, uncons, union, unionBy, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
 import Data.List.Lazy.NonEmpty as NEL
+import Data.Either (Either(..))
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Monoid.Additive (Additive(..))
 import Data.NonEmpty ((:|))
@@ -398,6 +399,11 @@ testListLazy = do
   assert let infs = iterate (_ + 1) 1
              infs' = scanrLazy (\i _ -> i) 0 infs
           in take 1000 infs == take 1000 infs'
+
+  log "foldrWhile should work ok on infinite lists"
+  assert let infs = iterate (_ + 1) 1
+             sum = foldrWhile (\i acc -> if i < 5 then Right (i + acc) else Left acc) 0 infs
+          in sum == 10
 
   log "can find the first 10 primes using lazy lists"
   let eratos :: List Int -> List Int

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -6,7 +6,7 @@ import Control.Lazy (defer)
 import Data.FoldableWithIndex (foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Lazy as Z
-import Data.List.Lazy (List, Pattern(..), alterAt, catMaybes, concat, concatMap, cons, delete, deleteAt, deleteBy, drop, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, foldMap, foldl, foldr, foldrLazy, foldrWhile, fromFoldable, group, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, iterate, last, length, mapMaybe, modifyAt, nil, nub, nubBy, null, partition, range, repeat, replicate, replicateM, reverse, scanrLazy, singleton, slice, snoc, span, stripPrefix, tail, take, takeWhile, transpose, uncons, union, unionBy, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
+import Data.List.Lazy (List, Pattern(..), alterAt, catMaybes, concat, concatMap, cons, delete, deleteAt, deleteBy, drop, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, foldMap, foldl, foldr, foldrLazy, foldlWhile, fromFoldable, group, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, iterate, last, length, mapMaybe, modifyAt, nil, nub, nubBy, null, partition, range, repeat, replicate, replicateM, reverse, scanrLazy, singleton, slice, snoc, span, stripPrefix, tail, take, takeWhile, transpose, uncons, union, unionBy, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
 import Data.List.Lazy.NonEmpty as NEL
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..), isNothing, fromJust)
@@ -400,9 +400,9 @@ testListLazy = do
              infs' = scanrLazy (\i _ -> i) 0 infs
           in take 1000 infs == take 1000 infs'
 
-  log "foldrWhile should work ok on infinite lists"
+  log "foldlWhile should work ok on infinite lists"
   assert let infs = iterate (_ + 1) 1
-             sum = foldrWhile (\i acc -> if i < 5 then Right (i + acc) else Left acc) 0 infs
+             sum = foldlWhile (\acc i -> if i < 5 then Right (i + acc) else Left acc) 0 infs
           in sum == 10
 
   log "can find the first 10 primes using lazy lists"

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -405,6 +405,9 @@ testListLazy = do
              sum = foldlWhile (\acc i -> if i < 5 then Right (i + acc) else Left acc) 0 infs
           in sum == 10
 
+  log "foldlWhile should be stack safe"
+  void $ pure $ foldlWhile (\acc i -> Right (acc + i)) 0 longList
+
   log "can find the first 10 primes using lazy lists"
   let eratos :: List Int -> List Int
       eratos xs = defer \_ ->


### PR DESCRIPTION
I'm not sure if this is something you'd like to add, but I've found this construct useful in other languages that support explicit lazy lists.

For example, both [rust](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.try_fold) and [elixir](https://hexdocs.pm/elixir/Enum.html#reduce_while/3) support something like this function.