### PR TITLE
Rename scanrLazy to scanlLazy and fix arg order

### DIFF
--- a/src/Data/List/Lazy.purs
+++ b/src/Data/List/Lazy.purs
@@ -89,7 +89,7 @@ module Data.List.Lazy
 
   , foldM
   , foldrLazy
-  , scanrLazy
+  , scanlLazy
 
   , module Exports
   ) where
@@ -757,12 +757,12 @@ foldrLazy op z = go
       Cons x xs' -> Z.defer \_ -> x `op` go xs'
       Nil -> z
 
--- | Perform a right scan lazily
-scanrLazy :: forall a b. (a -> b -> b) -> b -> List a -> List b
-scanrLazy f acc xs = List (go <$> unwrap xs)
+-- | Perform a left scan lazily
+scanlLazy :: forall a b. (b -> a -> b) -> b -> List a -> List b
+scanlLazy f acc xs = List (go <$> unwrap xs)
   where
     go :: Step a -> Step b
     go Nil = Nil
     go (Cons x xs') =
-      let acc' = f x acc
-       in Cons acc' $ scanrLazy f acc' xs'
+      let acc' = f acc x
+       in Cons acc' $ scanlLazy f acc' xs'

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -6,7 +6,7 @@ import Control.Lazy (defer)
 import Data.FoldableWithIndex (foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Lazy as Z
-import Data.List.Lazy (List, Pattern(..), alterAt, catMaybes, concat, concatMap, cons, delete, deleteAt, deleteBy, drop, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, foldMap, foldl, foldr, foldrLazy, fromFoldable, group, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, iterate, last, length, mapMaybe, modifyAt, nil, nub, nubBy, null, partition, range, repeat, replicate, replicateM, reverse, scanrLazy, singleton, slice, snoc, span, stripPrefix, tail, take, takeWhile, transpose, uncons, union, unionBy, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
+import Data.List.Lazy (List, Pattern(..), alterAt, catMaybes, concat, concatMap, cons, delete, deleteAt, deleteBy, drop, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, foldMap, foldl, foldr, foldrLazy, fromFoldable, group, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, iterate, last, length, mapMaybe, modifyAt, nil, nub, nubBy, null, partition, range, repeat, replicate, replicateM, reverse, scanlLazy, singleton, slice, snoc, span, stripPrefix, tail, take, takeWhile, transpose, uncons, union, unionBy, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
 import Data.List.Lazy.NonEmpty as NEL
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Monoid.Additive (Additive(..))
@@ -394,10 +394,13 @@ testListLazy = do
              infs' = foldrLazy cons nil infs
           in take 1000 infs == take 1000 infs'
 
-  log "scanrLazy should work ok on infinite lists"
+  log "scanlLazy should work ok on infinite lists"
   assert let infs = iterate (_ + 1) 1
-             infs' = scanrLazy (\i _ -> i) 0 infs
+             infs' = scanlLazy (\_ i -> i) 0 infs
           in take 1000 infs == take 1000 infs'
+
+  log "scanlLazy folds to the left"
+  assert $ scanlLazy (+) 5 (1..4) == l [6, 8, 11, 15]
 
   log "can find the first 10 primes using lazy lists"
   let eratos :: List Int -> List Int


### PR DESCRIPTION
The previously-named scanrLazy was actually folding to the left. I've
renamed the function and fixed the argument ordering for the folding
function.

Fixes #159 