### PR TITLE
Improve foldr performance ~4x on large lists

### DIFF
--- a/bench/Bench/Data/List.purs
+++ b/bench/Bench/Data/List.purs
@@ -1,9 +1,10 @@
 module Bench.Data.List where
 
 import Prelude
-import Data.Maybe (fromMaybe)
 import Data.Foldable (maximum)
-import Data.List (List(..), take, range, foldr, length, (:))
+import Data.Int (pow)
+import Data.List (List(..), take, range, foldr, length)
+import Data.Maybe (fromMaybe)
 import Data.Traversable (traverse_)
 import Effect (Effect)
 import Effect.Console (log)
@@ -16,7 +17,7 @@ benchList = do
 
   where
 
-  listSizes = 0 : 1 : 1000 : 2000 : 5000 : 10000 : 100000 : Nil
+  listSizes = Cons 0 $ map (pow 10) $ range 0 5
   nats = range 0 $ (fromMaybe 0 $ maximum listSizes) - 1
   lists = map (\n -> take n nats) listSizes
 

--- a/bench/Bench/Data/List.purs
+++ b/bench/Bench/Data/List.purs
@@ -1,48 +1,31 @@
 module Bench.Data.List where
 
 import Prelude
+import Data.Maybe (fromMaybe)
+import Data.Foldable (maximum)
+import Data.List (List(..), take, range, foldr, length, (:))
+import Data.Traversable (traverse_)
 import Effect (Effect)
 import Effect.Console (log)
 import Performance.Minibench (bench)
 
-import Data.List as L
-
 benchList :: Effect Unit
 benchList = do
-  log "map"
-  log "---"
-  benchMap
+  benchLists "map" $ map (_ + 1)
+  benchLists "foldr" $ foldr add 0
 
   where
 
-  benchMap = do
-    let nats = L.range 0 999999
-        mapFn = map (_ + 1)
-        list1000    = L.take 1000 nats
-        list2000    = L.take 2000 nats
-        list5000    = L.take 5000 nats
-        list10000   = L.take 10000 nats
-        list100000  = L.take 100000 nats
+  listSizes = 0 : 1 : 1000 : 2000 : 5000 : 10000 : 100000 : Nil
+  nats = range 0 $ (fromMaybe 0 $ maximum listSizes) - 1
+  lists = map (\n -> take n nats) listSizes
 
-    log "map: empty list"
-    let emptyList = L.Nil
-    bench \_ -> mapFn emptyList
+  benchLists :: forall b. String -> (List Int -> b) -> Effect Unit
+  benchLists label func =
+    traverse_ (benchAList label func) lists
 
-    log "map: singleton list"
-    let singletonList = L.Cons 0 L.Nil
-    bench \_ -> mapFn singletonList
-
-    log $ "map: list (" <> show (L.length list1000) <> " elems)"
-    bench \_ -> mapFn list1000
-
-    log $ "map: list (" <> show (L.length list2000) <> " elems)"
-    bench \_ -> mapFn list2000
-
-    log $ "map: list (" <> show (L.length list5000) <> " elems)"
-    bench \_ -> mapFn list5000
-
-    log $ "map: list (" <> show (L.length list10000) <> " elems)"
-    bench \_ -> mapFn list10000
-
-    log $ "map: list (" <> show (L.length list100000) <> " elems)"
-    bench \_ -> mapFn list100000
+  benchAList :: forall a b. String -> (List a -> b) -> List a -> Effect Unit
+  benchAList label func list = do
+    log "---"
+    log $ label <> ": list (" <> show (length list) <> " elems)"
+    bench \_ -> func list

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -103,7 +103,10 @@ instance functorWithIndexList :: FunctorWithIndex Int List where
 instance foldableList :: Foldable List where
   foldr f b = foldl (flip f) b <<< rev
     where
-    rev = foldl (flip Cons) Nil
+    rev = go Nil
+      where
+      go acc Nil = acc
+      go acc (x : xs) = go (x : acc) xs
   foldl f = go
     where
     go b = case _ of


### PR DESCRIPTION
Performance is improved by using an inlined reverse function, rather than leveraging `foldl`.

Both versions appear to be identical, so it's a bit of a bummer that the concise version is so much slower.

There's a moderate speedup for all list sizes, but it's most significant on large lists. Here are the benchmarking results:

Before:
```
foldr: list (0 elems)
mean   = 1.52 μs
stddev = 416.18 ns
min    = 1.22 μs
max    = 11.11 μs
---
foldr: list (1 elems)
mean   = 2.90 μs
stddev = 22.78 μs
min    = 977.00 ns
max    = 631.81 μs
---
foldr: list (10 elems)
mean   = 5.96 μs
stddev = 21.03 μs
min    = 2.00 μs
max    = 563.57 μs
---
foldr: list (100 elems)
mean   = 16.16 μs
stddev = 50.97 μs
min    = 10.32 μs
max    = 1.54 ms
---
foldr: list (1000 elems)
mean   = 126.53 μs
stddev = 77.85 μs
min    = 101.90 μs
max    = 1.40 ms
---
foldr: list (10000 elems)
mean   = 1.36 ms
stddev = 301.37 μs
min    = 1.17 ms
max    = 3.69 ms
---
foldr: list (100000 elems)
mean   = 22.66 ms
stddev = 3.63 ms
min    = 20.18 ms
max    = 43.71 ms
```
After:
```
foldr: list (0 elems)
mean   = 1.20 μs
stddev = 542.72 ns
min    = 772.00 ns
max    = 10.38 μs
---
foldr: list (1 elems)
mean   = 1.66 μs
stddev = 3.04 μs
min    = 806.00 ns
max    = 96.76 μs
---
foldr: list (10 elems)
mean   = 5.40 μs
stddev = 19.95 μs
min    = 1.05 μs
max    = 392.62 μs
---
foldr: list (100 elems)
mean   = 11.22 μs
stddev = 16.66 μs
min    = 4.67 μs
max    = 332.93 μs
---
foldr: list (1000 elems)
mean   = 53.27 μs
stddev = 40.41 μs
min    = 44.55 μs
max    = 529.10 μs
---
foldr: list (10000 elems)
mean   = 525.74 μs
stddev = 192.72 μs
min    = 450.25 μs
max    = 2.29 ms
---
foldr: list (100000 elems)
mean   = 4.66 ms
stddev = 2.23 ms
min    = 2.09 ms
max    = 12.26 ms
```

Also refactored the benchmarking code.