### PR TITLE
Idiomatic Show instance for lazy lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 - Renamed `scanrLazy` to `scanlLazy` and fixed parameter ordering (#161)
 - Renamed `group'` to `groupAll` (#182)
 - Changed `Alt ZipList` to satisfy distributivity (#150)
+- Updated the `Show` instances for (non empty) lazy lists (#181)
 
 New features:
 - Added `nubEq`/`nubByEq` (#179)

--- a/src/Data/List/Lazy/Types.purs
+++ b/src/Data/List/Lazy/Types.purs
@@ -34,6 +34,10 @@ newtype List a = List (Lazy (Step a))
 -- | `Cons` constructor).
 data Step a = Nil | Cons a (List a)
 
+instance showStep :: Show a => Show (Step a) where
+  show Nil = "Nil"
+  show (Cons x xs) = "(" <> show x <> " : " <> show xs <> ")"
+
 -- | Unwrap a lazy linked list
 step :: forall a. List a -> Step a
 step = force <<< unwrap
@@ -59,10 +63,12 @@ infixr 6 cons as :
 derive instance newtypeList :: Newtype (List a) _
 
 instance showList :: Show a => Show (List a) where
-  show xs = "fromStrict (" <> go (step xs) <> ")"
-    where
-    go Nil = "Nil"
-    go (Cons x xs') = "(Cons " <> show x <> " " <> go (step xs') <> ")"
+  show xs = "(fromFoldable ["
+         <> case step xs of
+              Nil -> ""
+              Cons x xs' ->
+                show x <> foldl (\shown x' -> shown <> "," <> show x') "" xs'
+         <> "])"
 
 instance eqList :: Eq a => Eq (List a) where
   eq = eq1


### PR DESCRIPTION
This pull request changes the output of show for Data.List.Lazy.Types.List and Data.List.Lazy.Types.NonEmptyList from this:

```purs
> Data.List.Lazy.fromFoldable [0, 1]
fromStrict ((Cons 0 (Cons 1 Nil)))

> Data.List.Lazy.NonEmpty.fromFoldable [0, 1]
(Just (NonEmptyList (defer \_ -> (NonEmpty 0 fromStrict ((Cons 1 Nil))))))
```

to that:

```purs
> Data.List.Lazy.fromFoldable [0, 1]
(defer \_ -> 0 : (defer \_ -> 1 : (defer \_ -> Nil)))

> Data.List.Lazy.NonEmpty.fromFoldable [0, 1]
(Just (NonEmptyList (defer \_ -> (NonEmpty 0 (defer \_ -> 1 : (defer \_ -> Nil))))))
```

Alternatively, we could show `(fromFoldable […])` but this makes the output of show less similar:

```purs
> Data.List.Lazy.fromFoldable [0, 1]
(fromFoldable [1,0])

> Data.List.Lazy.NonEmpty.fromFoldable [0, 1]
(Just (NonEmptyList (defer \_ -> (NonEmpty 0 (fromFoldable [1])))))
```

Close https://github.com/purescript/purescript-lists/issues/122.