### PR TITLE
Add Eq1 Ord1 to NonEmptyList LazyNonEmptyList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `Eq1` and `Ord1` instances to `NonEmptyList` and `LazyNonEmptyList` (#188)
 
 Bugfixes:
 

--- a/src/Data/List/Lazy/Types.purs
+++ b/src/Data/List/Lazy/Types.purs
@@ -211,8 +211,11 @@ derive instance newtypeNonEmptyList :: Newtype (NonEmptyList a) _
 derive newtype instance eqNonEmptyList :: Eq a => Eq (NonEmptyList a)
 derive newtype instance ordNonEmptyList :: Ord a => Ord (NonEmptyList a)
 
-derive newtype instance eq1NonEmptyList :: Eq1 NonEmptyList
-derive newtype instance ord1NonEmptyList :: Ord1 NonEmptyList
+instance eq1NonEmptyList :: Eq1 NonEmptyList where
+  eq1 (NonEmptyList lhs) (NonEmptyList rhs) = eq1 lhs rhs
+
+instance ord1NonEmptyList :: Ord1 NonEmptyList where
+  compare1 (NonEmptyList lhs) (NonEmptyList rhs) = compare1 lhs rhs
 
 instance showNonEmptyList :: Show a => Show (NonEmptyList a) where
   show (NonEmptyList nel) = "(NonEmptyList " <> show nel <> ")"

--- a/src/Data/List/Lazy/Types.purs
+++ b/src/Data/List/Lazy/Types.purs
@@ -211,6 +211,9 @@ derive instance newtypeNonEmptyList :: Newtype (NonEmptyList a) _
 derive newtype instance eqNonEmptyList :: Eq a => Eq (NonEmptyList a)
 derive newtype instance ordNonEmptyList :: Ord a => Ord (NonEmptyList a)
 
+derive newtype instance eq1NonEmptyList :: Eq1 NonEmptyList
+derive newtype instance ord1NonEmptyList :: Ord1 NonEmptyList
+
 instance showNonEmptyList :: Show a => Show (NonEmptyList a) where
   show (NonEmptyList nel) = "(NonEmptyList " <> show nel <> ")"
 

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -202,6 +202,9 @@ derive instance newtypeNonEmptyList :: Newtype (NonEmptyList a) _
 derive newtype instance eqNonEmptyList :: Eq a => Eq (NonEmptyList a)
 derive newtype instance ordNonEmptyList :: Ord a => Ord (NonEmptyList a)
 
+derive newtype instance eq1NonEmptyList :: Eq1 NonEmptyList
+derive newtype instance ord1NonEmptyList :: Ord1 NonEmptyList
+
 instance showNonEmptyList :: Show a => Show (NonEmptyList a) where
   show (NonEmptyList nel) = "(NonEmptyList " <> show nel <> ")"
 


### PR DESCRIPTION
**Description of the change**

Adds `Eq1` and `Ord1` instances to `NonEmptyList` and `LazyNonEmptyList`
Fixes #186

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
