### PR TITLE
Revise groupAllBy to just use an Ordering function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Change `groupAllBy` to use a comparison function (#191)
 
 New features:
 
@@ -28,7 +29,7 @@ Breaking changes:
 
 New features:
 - Added `nubEq`/`nubByEq` (#179)
-- Added `groupAllBy` (#182, #191) 
+- Added `groupAllBy` (#182)
 - Added `Eq1` and `Ord1` instances to `NonEmptyList` and `LazyNonEmptyList` (#188)
 
 Bugfixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Change `groupAllBy` to use a comparison function (#191)
 
 New features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
-- Change `groupAllBy` to use a comparison function (#191)
 - Rename `scanrLazy` to `scanlLazy` and fix parameter ordering (#161)
 - Rename `group'` to `groupAll` (#182)
 - Change `Alt ZipList` to satisfy distributivity (#150)

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -584,23 +584,25 @@ span _ xs = { init: Nil, rest: xs }
 
 -- | Group equal, consecutive elements of a list into lists.
 -- |
+-- | For example,
+-- |
 -- | ```purescript
--- | group (3 : 3 : 2 : 2 : 1 : 3 : Nil) ==
--- |   NonEmptyList (3 :| 3 : Nil) : NonEmptyList (2 :| 2 : Nil) : NonEmptyList (1 :| Nil) : NonEmptyList (3 :| Nil) : Nil
+-- | group (1 : 1 : 2 : 2 : 1 : Nil) ==
+-- |   (NonEmptyList (NonEmpty 1 (1 : Nil))) : (NonEmptyList (NonEmpty 2 (2 : Nil))) : (NonEmptyList (NonEmpty 1 Nil)) : Nil
 -- | ```
 -- |
 -- | Running time: `O(n)`
 group :: forall a. Eq a => List a -> List (NEL.NonEmptyList a)
 group = groupBy (==)
 
--- | Sort, then group equal elements of a list into lists.
+-- | Group equal elements of a list into lists.
+-- |
+-- | For example,
 -- |
 -- | ```purescript
--- | groupAll (3 : 3 : 2 : 2 : 1 : 3 : Nil) ==
--- |   NonEmptyList (1 :| Nil) : NonEmptyList (2 :| 2 : Nil) : NonEmptyList (3 :| 3 : 3 : Nil) : Nil
+-- | groupAll (1 : 1 : 2 : 2 : 1 : Nil) ==
+-- |   (NonEmptyList (NonEmpty 1 (1 : 1 : Nil))) : (NonEmptyList (NonEmpty 2 (2 : Nil))) : Nil
 -- | ```
--- |
--- | Running time: `O(n log n)`
 groupAll :: forall a. Ord a => List a -> List (NEL.NonEmptyList a)
 groupAll = group <<< sort
 
@@ -608,12 +610,14 @@ groupAll = group <<< sort
 group' :: forall a. Warn (Text "'group\'' is deprecated, use groupAll instead") => Ord a => List a -> List (NEL.NonEmptyList a)
 group' = groupAll
 
--- | Group equal, consecutive elements of a list into lists, using the provided
--- | equivalence function to determine equality.
+-- | Group equal, consecutive elements of a list into lists, using the specified
+-- | equivalence relation to determine equality.
+-- |
+-- | For example,
 -- |
 -- | ```purescript
--- | groupBy (eq `on` (_ `div` 10)) (32 : 31 : 21 : 22 : 11 : 33 : Nil) ==
--- |   NonEmptyList (32 :| 31 : Nil) : NonEmptyList (21 :| 22 : Nil) : NonEmptyList (11 :| Nil) : NonEmptyList (33 :| Nil) : Nil
+-- | groupBy (\a b -> odd a && odd b) (1 : 3 : 2 : 4 : 3 : 3 : Nil) ==
+-- |   (NonEmptyList (NonEmpty 1 (3 : Nil))) : (NonEmptyList (NonEmpty 2 Nil)) : (NonEmptyList (NonEmpty 4 Nil)) : (NonEmptyList (NonEmpty 3 (3 : Nil))) : Nil
 -- | ```
 -- |
 -- | Running time: `O(n)`

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -586,7 +586,7 @@ span _ xs = { init: Nil, rest: xs }
 -- |
 -- | ```purescript
 -- | group (3 : 3 : 2 : 2 : 1 : 3 : Nil) ==
--- |   (3 :|| 3 : Nil) : (2 :|| 2 : Nil) : (1 :|| Nil) : (3 :|| Nil) : Nil
+-- |   NonEmptyList (3 :| 3 : Nil) : NonEmptyList (2 :| 2 : Nil) : NonEmptyList (1 :| Nil) : NonEmptyList (3 :| Nil) : Nil
 -- | ```
 -- |
 -- | Running time: `O(n)`
@@ -597,7 +597,7 @@ group = groupBy (==)
 -- |
 -- | ```purescript
 -- | groupAll (3 : 3 : 2 : 2 : 1 : 3 : Nil) ==
--- |   (1 :|| Nil) : (2 :|| 2 : Nil) : (3 :|| 3 : 3 : Nil) : Nil
+-- |   NonEmptyList (1 :| Nil) : NonEmptyList (2 :| 2 : Nil) : NonEmptyList (3 :| 3 : 3 : Nil) : Nil
 -- | ```
 -- |
 -- | Running time: `O(n log n)`
@@ -613,7 +613,7 @@ group' = groupAll
 -- |
 -- | ```purescript
 -- | groupBy (eq `on` (_ `div` 10)) (32 : 31 : 21 : 22 : 11 : 33 : Nil) ==
--- |   (32 :|| 31 : Nil) : (21 :|| 22 : Nil) : (11 :|| Nil) : (33 :|| Nil) : Nil
+-- |   NonEmptyList (32 :| 31 : Nil) : NonEmptyList (21 :| 22 : Nil) : NonEmptyList (11 :| Nil) : NonEmptyList (33 :| Nil) : Nil
 -- | ```
 -- |
 -- | Running time: `O(n)`
@@ -626,7 +626,7 @@ groupBy eq (x : xs) = case span (eq x) xs of
 -- |
 -- | ```purescript
 -- | groupAllBy (compare `on` (_ `div` 10)) (32 : 31 : 21 : 22 : 11 : 33 : Nil) ==
--- |   (11 :|| Nil) : (21 :|| 22 : Nil) : (32 :|| 31 : 33) : Nil
+-- |   NonEmptyList (11 :| Nil) : NonEmptyList (21 :| 22 : Nil) : NonEmptyList (32 :| 31 : 33) : Nil
 -- | ```
 -- |
 -- | Running time: `O(n log n)`

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -584,25 +584,23 @@ span _ xs = { init: Nil, rest: xs }
 
 -- | Group equal, consecutive elements of a list into lists.
 -- |
--- | For example,
--- |
 -- | ```purescript
--- | group (1 : 1 : 2 : 2 : 1 : Nil) ==
--- |   (NonEmptyList (NonEmpty 1 (1 : Nil))) : (NonEmptyList (NonEmpty 2 (2 : Nil))) : (NonEmptyList (NonEmpty 1 Nil)) : Nil
+-- | group (3 : 3 : 2 : 2 : 1 : 3 : Nil) ==
+-- |   (3 :|| 3 : Nil) : (2 :|| 2 : Nil) : (1 :|| Nil) : (3 :|| Nil) : Nil
 -- | ```
 -- |
 -- | Running time: `O(n)`
 group :: forall a. Eq a => List a -> List (NEL.NonEmptyList a)
 group = groupBy (==)
 
--- | Group equal elements of a list into lists.
--- |
--- | For example,
+-- | Sort, then group equal elements of a list into lists.
 -- |
 -- | ```purescript
--- | groupAll (1 : 1 : 2 : 2 : 1 : Nil) ==
--- |   (NonEmptyList (NonEmpty 1 (1 : 1 : Nil))) : (NonEmptyList (NonEmpty 2 (2 : Nil))) : Nil
+-- | groupAll (3 : 3 : 2 : 2 : 1 : 3 : Nil) ==
+-- |   (1 :|| Nil) : (2 :|| 2 : Nil) : (3 :|| 3 : 3 : Nil) : Nil
 -- | ```
+-- |
+-- | Running time: `O(n log n)`
 groupAll :: forall a. Ord a => List a -> List (NEL.NonEmptyList a)
 groupAll = group <<< sort
 
@@ -610,14 +608,12 @@ groupAll = group <<< sort
 group' :: forall a. Warn (Text "'group\'' is deprecated, use groupAll instead") => Ord a => List a -> List (NEL.NonEmptyList a)
 group' = groupAll
 
--- | Group equal, consecutive elements of a list into lists, using the specified
--- | equivalence relation to determine equality.
--- |
--- | For example,
+-- | Group equal, consecutive elements of a list into lists, using the provided
+-- | equivalence function to determine equality.
 -- |
 -- | ```purescript
--- | groupBy (\a b -> odd a && odd b) (1 : 3 : 2 : 4 : 3 : 3 : Nil) ==
--- |   (NonEmptyList (NonEmpty 1 (3 : Nil))) : (NonEmptyList (NonEmpty 2 Nil)) : (NonEmptyList (NonEmpty 4 Nil)) : (NonEmptyList (NonEmpty 3 (3 : Nil))) : Nil
+-- | groupBy (eq `on` (_ `div` 10)) (32 : 31 : 21 : 22 : 11 : 33 : Nil) ==
+-- |   (32 :|| 31 : Nil) : (21 :|| 22 : Nil) : (11 :|| Nil) : (33 :|| Nil) : Nil
 -- | ```
 -- |
 -- | Running time: `O(n)`
@@ -626,17 +622,16 @@ groupBy _ Nil = Nil
 groupBy eq (x : xs) = case span (eq x) xs of
   { init: ys, rest: zs } -> NEL.NonEmptyList (x :| ys) : groupBy eq zs
 
--- | Group equal elements of a list into lists, using the specified
--- | equivalence relation to determine equality.
--- |
--- | For example,
+-- | Sort, then group equal elements of a list into lists, using the provided comparison function.
 -- |
 -- | ```purescript
--- | groupAllBy (\a b -> odd a && odd b) (1 : 3 : 2 : 4 : 3 : 3 : Nil) ==
--- |    (NonEmptyList (NonEmpty 1 Nil)) : (NonEmptyList (NonEmpty 2 Nil)) : (NonEmptyList (NonEmpty 3 (3 : 3 : Nil))) : (NonEmptyList (NonEmpty 4 Nil)) : Nil
+-- | groupAllBy (compare `on` (_ `div` 10)) (32 : 31 : 21 : 22 : 11 : 33 : Nil) ==
+-- |   (11 :|| Nil) : (21 :|| 22 : Nil) : (32 :|| 31 : 33) : Nil
 -- | ```
-groupAllBy :: forall a. Ord a => (a -> a -> Boolean) -> List a -> List (NEL.NonEmptyList a)
-groupAllBy p = groupBy p <<< sort
+-- |
+-- | Running time: `O(n log n)`
+groupAllBy :: forall a. (a -> a -> Ordering) -> List a -> List (NEL.NonEmptyList a)
+groupAllBy p = groupBy (\x y -> p x y == EQ) <<< sortBy p
 
 -- | Returns a lists of elements which do and do not satisfy a predicate.
 -- |

--- a/src/Data/List/NonEmpty.purs
+++ b/src/Data/List/NonEmpty.purs
@@ -272,7 +272,7 @@ group' = groupAll
 groupBy :: forall a. (a -> a -> Boolean) -> NonEmptyList a -> NonEmptyList (NonEmptyList a)
 groupBy = wrappedOperation "groupBy" <<< L.groupBy
 
-groupAllBy :: forall a. Ord a => (a -> a -> Boolean) -> NonEmptyList a -> NonEmptyList (NonEmptyList a)
+groupAllBy :: forall a. (a -> a -> Ordering) -> NonEmptyList a -> NonEmptyList (NonEmptyList a)
 groupAllBy = wrappedOperation "groupAllBy" <<< L.groupAllBy
 
 partition :: forall a. (a -> Boolean) -> NonEmptyList a -> { yes :: L.List a, no :: L.List a }

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -270,13 +270,13 @@ testList = do
   assert $ spanResult.rest == l [4, 5, 6, 7]
 
   log "group should group consecutive equal elements into lists"
-  assert $ group (l [3, 3, 2, 2, 1, 3]) == l [nel 3 [3], nel 2 [2], nel 1 [], nel 3 []]
+  assert $ group (l [1, 2, 2, 3, 3, 3, 1]) == l [NEL.singleton 1, NEL.NonEmptyList (2 :| l [2]), NEL.NonEmptyList (3 :| l [3, 3]), NEL.singleton 1]
 
-  log "groupAll should sort then group equal elements into lists"
-  assert $ groupAll (l [3, 3, 2, 2, 1, 3]) == l [nel 1 [], nel 2 [2], nel 3 [3, 3]]
+  log "groupAll should group equal elements into lists"
+  assert $ groupAll (l [1, 2, 2, 3, 3, 3, 1]) == l [NEL.NonEmptyList (1 :| l [1]), NEL.NonEmptyList (2 :| l [2]), NEL.NonEmptyList (3 :| l [3, 3])]
 
   log "groupBy should group consecutive equal elements into lists based on an equivalence relation"
-  assert $ groupBy (eq `on` (_ `div` 10)) (l [32, 31, 21, 22, 11, 33]) == l [nel 32 [31], nel 21 [22], nel 11 [], nel 33 []]
+  assert $ groupBy (\x y -> odd x && odd y) (l [1, 1, 2, 2, 3, 3]) == l [NEL.NonEmptyList (1 :| l [1]), NEL.singleton 2, NEL.singleton 2, NEL.NonEmptyList (3 :| l [3])]
 
   log "groupAllBy should sort then group equal elements into lists based on a comparison function"
   assert $ groupAllBy (compare `on` (_ `div` 10)) (l [32, 31, 21, 22, 11, 33]) == l [nel 11 [], nel 21 [22], nel 32 [31, 33]]

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -25,7 +25,7 @@ testList = do
   let
     l = fromFoldable
 
-    nel :: ∀ f a. Foldable f => a -> f a -> NEL.NonEmptyList a
+    nel :: forall f a. Foldable f => a -> f a -> NEL.NonEmptyList a
     nel x xs = NEL.NonEmptyList $ x :| fromFoldable xs
 
   log "strip prefix"

--- a/test/Test/Data/List/NonEmpty.purs
+++ b/test/Test/Data/List/NonEmpty.purs
@@ -167,13 +167,13 @@ testNonEmptyList = do
   assert $ spanResult.rest == l [4, 5, 6, 7]
 
   log "group should group consecutive equal elements into lists"
-  assert $ NEL.group (nel 3 [3, 2, 2, 1, 3]) == nel (nel 3 [3]) [nel 2 [2], nel 1 [], nel 3 []]
+  assert $ NEL.group (nel 1 [2, 2, 3, 3, 3, 1]) == nel (nel 1 []) [nel 2 [2], nel 3 [3, 3], nel 1 []]
 
-  log "groupAll should sort then group equal elements into lists"
-  assert $ NEL.groupAll (nel 3 [3, 2, 2, 1, 3]) == nel (nel 1 []) [nel 2 [2], nel 3 [3, 3]]
+  log "groupAll should group equal elements into lists"
+  assert $ NEL.groupAll (nel 1 [2, 2, 3, 3, 3, 1]) == nel (nel 1 [1]) [nel 2 [2], nel 3 [3, 3]]
 
   log "groupBy should group consecutive equal elements into lists based on an equivalence relation"
-  assert $ NEL.groupBy (eq `on` (_ `div` 10)) (nel 32 [31, 21, 22, 11, 33]) == nel (nel 32 [31]) [nel 21 [22], nel 11 [], nel 33 []]
+  assert $ NEL.groupBy (\x y -> odd x && odd y) (nel 1 [1, 2, 2, 3, 3]) == nel (nel 1 [1]) [nel 2 [], nel 2 [], nel 3 [3]]
 
   log "groupAllBy should sort then group equal elements into lists based on a comparison function"
   assert $ NEL.groupAllBy (compare `on` (_ `div` 10)) (nel 32 [31, 21, 22, 11, 33]) == nel (nel 11 []) [nel 21 [22], nel 32 [31, 33]]

--- a/test/Test/Data/List/NonEmpty.purs
+++ b/test/Test/Data/List/NonEmpty.purs
@@ -20,9 +20,9 @@ import Test.Assert (assert)
 testNonEmptyList :: Effect Unit
 testNonEmptyList = do
   let
-    nel :: ∀ f a. Foldable f => a -> f a -> NEL.NonEmptyList a
+    nel :: forall f a. Foldable f => a -> f a -> NEL.NonEmptyList a
     nel x xs = NEL.NonEmptyList $ x :| L.fromFoldable xs
-    l :: ∀ f a. Foldable f => f a -> L.List a
+    l :: forall f a. Foldable f => f a -> L.List a
     l = L.fromFoldable
 
   log "singleton should construct a non-empty list with a single value"

--- a/test/Test/Data/List/NonEmpty.purs
+++ b/test/Test/Data/List/NonEmpty.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Data.Foldable (class Foldable, foldM, foldMap, foldl, length)
 import Data.FoldableWithIndex (foldlWithIndex, foldrWithIndex, foldMapWithIndex)
+import Data.Function (on)
 import Data.List as L
 import Data.List.NonEmpty as NEL
 import Data.Maybe (Maybe(..))
@@ -166,16 +167,16 @@ testNonEmptyList = do
   assert $ spanResult.rest == l [4, 5, 6, 7]
 
   log "group should group consecutive equal elements into lists"
-  assert $ NEL.group (nel 1 [2, 2, 3, 3, 3, 1]) == nel (nel 1 []) [nel 2 [2], nel 3 [3, 3], nel 1 []]
+  assert $ NEL.group (nel 3 [3, 2, 2, 1, 3]) == nel (nel 3 [3]) [nel 2 [2], nel 1 [], nel 3 []]
 
-  log "groupAll should group equal elements into lists"
-  assert $ NEL.groupAll (nel 1 [2, 2, 3, 3, 3, 1]) == nel (nel 1 [1]) [nel 2 [2], nel 3 [3, 3]]
+  log "groupAll should sort then group equal elements into lists"
+  assert $ NEL.groupAll (nel 3 [3, 2, 2, 1, 3]) == nel (nel 1 []) [nel 2 [2], nel 3 [3, 3]]
 
   log "groupBy should group consecutive equal elements into lists based on an equivalence relation"
-  assert $ NEL.groupBy (\x y -> odd x && odd y) (nel 1 [1, 2, 2, 3, 3]) == nel (nel 1 [1]) [nel 2 [], nel 2 [], nel 3 [3]]
+  assert $ NEL.groupBy (eq `on` (_ `div` 10)) (nel 32 [31, 21, 22, 11, 33]) == nel (nel 32 [31]) [nel 21 [22], nel 11 [], nel 33 []]
 
-  log "groupAllBy should group equal elements into lists based on an equivalence relation"
-  assert $ NEL.groupAllBy (\x y -> odd x && odd y) (nel 1 [3, 2, 4, 3, 3]) == nel (nel 1 []) [nel 2 [], nel 3 [3, 3], nel 4 []]
+  log "groupAllBy should sort then group equal elements into lists based on a comparison function"
+  assert $ NEL.groupAllBy (compare `on` (_ `div` 10)) (nel 32 [31, 21, 22, 11, 33]) == nel (nel 11 []) [nel 21 [22], nel 32 [31, 33]]
 
   log "partition should separate a list into a tuple of lists that do and do not satisfy a predicate"
   let partitioned = NEL.partition (_ > 2) (nel 1 [5, 3, 2, 4])


### PR DESCRIPTION
**Description of the change**

Fixes #189

Also modified the tests and examples to demonstrate which grouping functions involve sorting.

One of the commits reverts demoing the convenience of the `:||` infix operator proposed in #190. We can redo those changes if that operator is accepted.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
