### PR TITLE
Fix ad-hoc usage of case expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Fix ad-hoc usage of case expression (#202 by @JordanMartinez)
 
 ## [v6.0.1](https://github.com/purescript/purescript-lists/releases/tag/v6.0.1) - 2021-04-19
 

--- a/src/Data/List/Lazy/NonEmpty.purs
+++ b/src/Data/List/Lazy/NonEmpty.purs
@@ -66,8 +66,8 @@ tail (NonEmptyList nel) = case force nel of _ :| xs -> xs
 
 init :: NonEmptyList ~> L.List
 init (NonEmptyList nel) =
-  case force nel
-    of x :| xs ->
+  case force nel of
+    x :| xs ->
       maybe L.nil (x : _) (L.init xs)
 
 cons :: forall a. a -> NonEmptyList a -> NonEmptyList a


### PR DESCRIPTION
**Description of the change**

See https://github.com/purescript/purescript/pull/4241. In preparation for `v0.15.x`, fixes the ad-hoc case expression usage.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
