### PR TITLE
Drop deprecated `group'` and `mapWithIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 - Update project and deps to PureScript v0.15.0 (#203 by @JordanMartinez)
 - Drop deprecated `MonadZero` instance (#205 by @JordanMartinez)
+- Drop deprecated `group'` and `mapWithIndex` (#206 by @JordanMartinez)
 
 New features:
 

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -51,7 +51,6 @@ module Data.List
   , filterM
   , mapMaybe
   , catMaybes
-  , mapWithIndex
 
   , sort
   , sortBy
@@ -68,7 +67,6 @@ module Data.List
   , span
   , group
   , groupAll
-  , group'
   , groupBy
   , groupAllBy
   , partition
@@ -429,13 +427,6 @@ mapMaybe f = go Nil
 catMaybes :: forall a. List (Maybe a) -> List a
 catMaybes = mapMaybe identity
 
-
--- | Apply a function to each element and its index in a list starting at 0.
--- |
--- | Deprecated. Use Data.FunctorWithIndex instead.
-mapWithIndex :: forall a b. (Int -> a -> b) -> List a -> List b
-mapWithIndex = FWI.mapWithIndex
-
 --------------------------------------------------------------------------------
 -- Sorting ---------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -605,10 +596,6 @@ group = groupBy (==)
 -- | ```
 groupAll :: forall a. Ord a => List a -> List (NEL.NonEmptyList a)
 groupAll = group <<< sort
-
--- | Deprecated previous name of `groupAll`.
-group' :: forall a. Warn (Text "'group\'' is deprecated, use groupAll instead") => Ord a => List a -> List (NEL.NonEmptyList a)
-group' = groupAll
 
 -- | Group equal, consecutive elements of a list into lists, using the specified
 -- | equivalence relation to determine equality.

--- a/src/Data/List/NonEmpty.purs
+++ b/src/Data/List/NonEmpty.purs
@@ -32,7 +32,6 @@ module Data.List.NonEmpty
   , mapMaybe
   , catMaybes
   , appendFoldable
-  , mapWithIndex
   , sort
   , sortBy
   , take
@@ -42,7 +41,6 @@ module Data.List.NonEmpty
   , span
   , group
   , groupAll
-  , group'
   , groupBy
   , groupAllBy
   , partition
@@ -235,12 +233,6 @@ appendFoldable :: forall t a. Foldable t => NonEmptyList a -> t a -> NonEmptyLis
 appendFoldable (NonEmptyList (x :| xs)) ys =
   NonEmptyList (x :| (xs <> L.fromFoldable ys))
 
--- | Apply a function to each element and its index in a list starting at 0.
--- |
--- | Deprecated. Use Data.FunctorWithIndex instead.
-mapWithIndex :: forall a b. (Int -> a -> b) -> NonEmptyList a -> NonEmptyList b
-mapWithIndex = FWI.mapWithIndex
-
 sort :: forall a. Ord a => NonEmptyList a -> NonEmptyList a
 sort xs = sortBy compare xs
 
@@ -267,9 +259,6 @@ group = wrappedOperation "group" L.group
 
 groupAll :: forall a. Ord a => NonEmptyList a -> NonEmptyList (NonEmptyList a)
 groupAll = wrappedOperation "groupAll" L.groupAll
-
-group' :: forall a. Warn (Text "'group\'' is deprecated, use groupAll instead") => Ord a => NonEmptyList a -> NonEmptyList (NonEmptyList a)
-group' = groupAll
 
 groupBy :: forall a. (a -> a -> Boolean) -> NonEmptyList a -> NonEmptyList (NonEmptyList a)
 groupBy = wrappedOperation "groupBy" <<< L.groupBy


### PR DESCRIPTION
**Description of the change**

Drop deprecated things

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
