### PR TITLE
Add inits & tails

### DIFF
--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -30,6 +30,7 @@ module Data.List
   , last
   , tail
   , init
+  , tails
   , uncons
   , unsnoc
 
@@ -105,7 +106,7 @@ import Data.Bifunctor (bimap)
 import Data.Foldable (class Foldable, foldr, any, foldl)
 import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, elem, notElem, find, findMap, any, all) as Exports
 import Data.List.Internal (emptySet, insertAndLookupBy)
-import Data.List.Types (List(..), (:))
+import Data.List.Types (List(..), nelCons, (:))
 import Data.List.Types (NonEmptyList(..)) as NEL
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
@@ -632,15 +633,28 @@ partition p xs = foldr select { no: Nil, yes: Nil } xs
                            then { no, yes: x : yes }
                            else { no: x : no, yes }
 
--- | Returns all final segments of the argument, longest first. For example,
--- |
--- | ```purescript
--- | tails (1 : 2 : 3 : Nil) == ((1 : 2 : 3 : Nil) : (2 : 3 : Nil) : (3 : Nil) : (Nil) : Nil)
+-- | Returns all the final segments of the argument, longest first.
 -- | ```
+-- | tails (1 : 2 : 3 : Nil) == (
+-- |       (1 : 2 : 3 : Nil)
+-- |     : (1 : 2 : Nil) 
+-- |     : (1 : Nil)
+-- |     : (Nil)
+-- |     : Nil
+-- | )
+-- | ```
+-- | 
 -- | Running time: `O(n)`
-tails :: forall a. List a -> List (List a)
-tails Nil = singleton Nil
-tails list@(Cons _ tl)= list : tails tl
+tails :: forall a. List a -> NEL.NonEmptyList (List a)
+tails = go Nil
+  where
+  go acc = case _ of
+    Nil -> reverseAppend (pure Nil) acc
+    ls@(Cons _ t) -> go (ls : acc) t
+
+  reverseAppend initial = case _ of
+    Nil -> initial
+    Cons h t -> reverseAppend (nelCons h initial) t
 
 --------------------------------------------------------------------------------
 -- Set-like operations ---------------------------------------------------------

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -30,6 +30,7 @@ module Data.List
   , last
   , tail
   , init
+  , inits
   , tails
   , uncons
   , unsnoc
@@ -252,6 +253,33 @@ tail (_ : xs) = Just xs
 -- | Running time: `O(n)`
 init :: forall a. List a -> Maybe (List a)
 init lst = _.init <$> unsnoc lst
+
+-- | Returns all the initial segments of the argument, shortest first.
+-- | ```
+-- | inits (1 : 2 : 3 : Nil) == (
+-- |       (Nil) 
+-- |     : (1 : Nil)
+-- |     : (1 : 2 : Nil)
+-- |     : (1 : 2 : 3 : Nil) 
+-- |     : Nil
+-- | )
+-- | ```
+-- | 
+-- | Running time: `O(n)`
+inits :: forall a. List a -> NEL.NonEmptyList (List a)
+inits = go Nil Nil
+  where
+  go :: List (List a) -> List a -> List a -> NEL.NonEmptyList (List a)
+  go acc lastInit = case _ of
+    Nil -> NEL.NonEmptyList $ Nil :| reverseInnards Nil acc
+    Cons h t -> do
+      let nextInit = h : lastInit
+      go (nextInit : acc) nextInit t
+
+  reverseInnards :: List (List a) -> List (List a) -> List (List a)
+  reverseInnards acc = case _ of
+    Nil -> acc
+    Cons h t -> reverseInnards ((reverse h) : acc) t
 
 -- | Break a list into its first element, and the remaining elements,
 -- | or `Nothing` if the list is empty.

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -6,7 +6,7 @@ import Data.Array as Array
 import Data.Foldable (class Foldable, foldMap, foldl)
 import Data.FoldableWithIndex (foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.Function (on)
-import Data.List (List(..), Pattern(..), alterAt, catMaybes, concat, concatMap, delete, deleteAt, deleteBy, drop, dropEnd, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, fromFoldable, group, groupAll, groupAllBy, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, last, length, mapMaybe, modifyAt, nub, nubBy, nubByEq, nubEq, null, partition, range, reverse, singleton, snoc, sort, sortBy, span, stripPrefix, tail, tails, take, takeEnd, takeWhile, transpose, uncons, union, unionBy, unsnoc, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
+import Data.List (List(..), Pattern(..), alterAt, catMaybes, concat, concatMap, delete, deleteAt, deleteBy, drop, dropEnd, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, fromFoldable, group, groupAll, groupAllBy, groupBy, head, init, inits, insert, insertAt, insertBy, intersect, intersectBy, last, length, mapMaybe, modifyAt, nub, nubBy, nubByEq, nubEq, null, partition, range, reverse, singleton, snoc, sort, sortBy, span, stripPrefix, tail, tails, take, takeEnd, takeWhile, transpose, uncons, union, unionBy, unsnoc, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
 import Data.List.NonEmpty as NEL
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Monoid.Additive (Additive(..))
@@ -109,6 +109,12 @@ testList = do
 
   log "init should return Nothing for an empty list"
   assert $ init nil == Nothing
+
+  log "inits should return a non-empty list containing only Nil for an empty list"
+  assert $ inits nil == pure nil
+
+  log "inits should return the initial segments for a non-empty list"
+  assert $ inits (l [ 1, 2, 3 ]) == (nel Nil [ l [ 1 ], l [ 1, 2 ], l [ 1, 2, 3 ] ])
 
   log "tails should return a non-empty list containing only Nil for an empty list"
   assert $ tails nil == pure nil
@@ -416,6 +422,9 @@ testList = do
 
   log "append should be stack-safe"
   void $ pure $ xs <> xs
+
+  log "inits should be stack-safe"
+  assert $ Nil == (NEL.head $ inits $ fromFoldable $ range 1 100_000)
 
   log "tails should be stack-safe"
   assert $ 1 == NEL.head (1 <$ (tails $ fromFoldable $ range 1 100_000))

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -427,7 +427,7 @@ testList = do
   assert $ Nil == (NEL.head $ inits $ fromFoldable $ range 1 100_000)
 
   log "tails should be stack-safe"
-  assert $ 1 == NEL.head (1 <$ (tails $ fromFoldable $ range 1 100_000))
+  assert $ Nil == (NEL.tail $ tails $ fromFoldable $ range 1 100_000)
 
 step :: Int -> Maybe (Tuple Int Int)
 step 6 = Nothing

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -6,7 +6,7 @@ import Data.Array as Array
 import Data.Foldable (class Foldable, foldMap, foldl)
 import Data.FoldableWithIndex (foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.Function (on)
-import Data.List (List(..), Pattern(..), alterAt, catMaybes, concat, concatMap, delete, deleteAt, deleteBy, drop, dropEnd, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, fromFoldable, group, groupAll, groupAllBy, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, last, length, mapMaybe, modifyAt, nub, nubBy, nubByEq, nubEq, null, partition, range, reverse, singleton, snoc, sort, sortBy, span, stripPrefix, tail, take, takeEnd, takeWhile, transpose, uncons, union, unionBy, unsnoc, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
+import Data.List (List(..), Pattern(..), alterAt, catMaybes, concat, concatMap, delete, deleteAt, deleteBy, drop, dropEnd, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, fromFoldable, group, groupAll, groupAllBy, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, last, length, mapMaybe, modifyAt, nub, nubBy, nubByEq, nubEq, null, partition, range, reverse, singleton, snoc, sort, sortBy, span, stripPrefix, tail, tails, take, takeEnd, takeWhile, transpose, uncons, union, unionBy, unsnoc, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
 import Data.List.NonEmpty as NEL
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Monoid.Additive (Additive(..))
@@ -109,6 +109,12 @@ testList = do
 
   log "init should return Nothing for an empty list"
   assert $ init nil == Nothing
+
+  log "tails should return a non-empty list containing only Nil for an empty list"
+  assert $ tails nil == pure nil
+
+  log "tails should return the final segments for a non-empty list"
+  assert $ tails (l [ 1, 2, 3 ]) == (nel (l [ 1, 2, 3 ]) [ l [ 2, 3 ], l [ 3 ], Nil ])
 
   log "uncons should return nothing when used on an empty list"
   assert $ isNothing (uncons nil)
@@ -410,6 +416,9 @@ testList = do
 
   log "append should be stack-safe"
   void $ pure $ xs <> xs
+
+  log "tails should be stack-safe"
+  assert $ 1 == NEL.head (1 <$ (tails $ fromFoldable $ range 1 100_000))
 
 step :: Int -> Maybe (Tuple Int Int)
 step 6 = Nothing


### PR DESCRIPTION
**Description of the change**

- Export `tails`; make it stack safe
- Implement `inits`

Note: the `inits` test currently fails with a "JavaScript heap out of memory" error because we're duplicating a list with 100k elements 999,999 times. Thoughts on how this should proceed?

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
