### PR TITLE
Change type signatures of `Data.List.NonEmpty.intersect` and `Data.List.NonEmpty.intersectBy` to return a `List` instead of a `NonEmptyList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 
+- Changed type signatures of `Data.List.NonEmpty.intersect` and `Data.List.NonEmpty.intersectBy` to return a `List` instead of a `NonEmptyList` (#217)
+
 New features:
 
 Bugfixes:

--- a/src/Data/List/NonEmpty.purs
+++ b/src/Data/List/NonEmpty.purs
@@ -284,11 +284,11 @@ union = wrappedOperation2 "union" L.union
 unionBy :: forall a. (a -> a -> Boolean) -> NonEmptyList a -> NonEmptyList a -> NonEmptyList a
 unionBy = wrappedOperation2 "unionBy" <<< L.unionBy
 
-intersect :: forall a. Eq a => NonEmptyList a -> NonEmptyList a -> NonEmptyList a
-intersect = wrappedOperation2 "intersect" L.intersect
+intersect :: forall a. Eq a => NonEmptyList a -> NonEmptyList a -> L.List a
+intersect = intersectBy eq
 
-intersectBy :: forall a. (a -> a -> Boolean) -> NonEmptyList a -> NonEmptyList a -> NonEmptyList a
-intersectBy = wrappedOperation2 "intersectBy" <<< L.intersectBy
+intersectBy :: forall a. (a -> a -> Boolean) -> NonEmptyList a -> NonEmptyList a -> L.List a
+intersectBy eq xs ys = L.intersectBy eq (toList xs) (toList ys)
 
 zipWith :: forall a b c. (a -> b -> c) -> NonEmptyList a -> NonEmptyList b -> NonEmptyList c
 zipWith f (NonEmptyList (x :| xs)) (NonEmptyList (y :| ys)) =

--- a/test/Test/Data/List/NonEmpty.purs
+++ b/test/Test/Data/List/NonEmpty.purs
@@ -203,10 +203,13 @@ testNonEmptyList = do
   assert $ NEL.unionBy (\_ y -> y < 5) (nel 1 [2, 3]) (nel 2 [3, 4, 5, 6]) == nel 1 [2, 3, 5, 6]
 
   log "intersect should return the intersection of two lists"
-  assert $ NEL.intersect (nel 1 [2, 3, 4, 3, 2, 1]) (nel 1 [1, 2, 3]) == nel 1 [2, 3, 3, 2, 1]
+  assert $ NEL.intersect (nel 1 [2, 3, 4, 3, 2, 1]) (nel 1 [1, 2, 3]) == L.fromFoldable [1, 2, 3, 3, 2, 1]
+
+  log "intersect should return empty list when lists do not intersect"
+  assert $ NEL.intersect (nel 1 [2, 3, 4, 3, 2, 1]) (nel 5 [6, 7, 8]) == L.Nil
 
   log "intersectBy should return the intersection of two lists using the specified equivalence relation"
-  assert $ NEL.intersectBy (\x y -> (x * 2) == y) (nel 1 [2, 3]) (nel 2 [6]) == nel 1 [3]
+  assert $ NEL.intersectBy (\x y -> (x * 2) == y) (nel 1 [2, 3]) (nel 2 [6]) == L.fromFoldable [1, 3]
 
   log "zipWith should use the specified function to zip two lists together"
   assert $ NEL.zipWith (\x y -> nel (show x) [y]) (nel 1 [2, 3]) (nel "a" ["b", "c"]) == nel (nel "1" ["a"]) [nel "2" ["b"], nel "3" ["c"]]


### PR DESCRIPTION
**Description of the change**

Clearly and concisely describe the purpose of the pull request. If this PR relates to an existing issue or change proposal, please link to it. Include any other background context that would help reviewers understand the motivation for this PR.

Changed type signatures of `Data.List.NonEmpty.intersect` and `Data.List.NonEmpty.intersectBy` to return a `List` instead of a `NonEmptyList`. Fixes #216

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
