### PR TITLE
Law-abiding `Apply NonEmptyList` that agrees with `Apply List`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 
+- Change `Apply NonEmptyList` instance to obey `Apply` and `Applicative` laws
+
 New features:
 
 Bugfixes:
+
+- Change `Apply NonEmptyList` instance to obey `Apply` and `Applicative` laws
 
 Other improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 
-- Change `Apply NonEmptyList` instance to obey `Apply` and `Applicative` laws
+- Change `Apply NonEmptyList` instance to obey `Apply` and `Applicative` laws, and agree with `Apply List` (#222 by @UnrelatedString)
 
 New features:
 
 Bugfixes:
 
-- Change `Apply NonEmptyList` instance to obey `Apply` and `Applicative` laws
+- Change `Apply NonEmptyList` instance to obey `Apply` and `Applicative` laws, and agree with `Apply List` (#222 by @UnrelatedString)
 
 Other improvements:
 

--- a/src/Data/List/Lazy/Types.purs
+++ b/src/Data/List/Lazy/Types.purs
@@ -230,7 +230,7 @@ instance applyNonEmptyList :: Apply NonEmptyList where
   apply (NonEmptyList nefs) (NonEmptyList neas) =
     case force nefs, force neas of
       f :| fs, a :| as ->
-        NonEmptyList (defer \_ -> f a :| (fs <*> a : nil) <> ((f : fs) <*> as))
+        NonEmptyList (defer \_ -> f a :| map f as <> apply fs (a : as))
 
 instance applicativeNonEmptyList :: Applicative NonEmptyList where
   pure a = NonEmptyList (defer \_ -> NE.singleton a)

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -209,7 +209,7 @@ derive newtype instance functorNonEmptyList :: Functor NonEmptyList
 
 instance applyNonEmptyList :: Apply NonEmptyList where
   apply (NonEmptyList (f :| fs)) (NonEmptyList (a :| as)) =
-    NonEmptyList (f a :| (fs <*> a : Nil) <> ((f : fs) <*> as))
+    NonEmptyList (f a :| map f as <> (fs <*> (a : as)))
 
 instance applicativeNonEmptyList :: Applicative NonEmptyList where
   pure = NonEmptyList <<< NE.singleton

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -209,7 +209,7 @@ derive newtype instance functorNonEmptyList :: Functor NonEmptyList
 
 instance applyNonEmptyList :: Apply NonEmptyList where
   apply (NonEmptyList (f :| fs)) (NonEmptyList (a :| as)) =
-    NonEmptyList (f a :| map f as <> apply fs <*> (a : as))
+    NonEmptyList (f a :| map f as <> apply fs (a : as))
 
 instance applicativeNonEmptyList :: Applicative NonEmptyList where
   pure = NonEmptyList <<< NE.singleton

--- a/src/Data/List/Types.purs
+++ b/src/Data/List/Types.purs
@@ -209,7 +209,7 @@ derive newtype instance functorNonEmptyList :: Functor NonEmptyList
 
 instance applyNonEmptyList :: Apply NonEmptyList where
   apply (NonEmptyList (f :| fs)) (NonEmptyList (a :| as)) =
-    NonEmptyList (f a :| map f as <> (fs <*> (a : as)))
+    NonEmptyList (f a :| map f as <> apply fs <*> (a : as))
 
 instance applicativeNonEmptyList :: Applicative NonEmptyList where
   pure = NonEmptyList <<< NE.singleton

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -12,7 +12,7 @@ import Data.List.Lazy (List, Pattern(..), alterAt, catMaybes, concat, concatMap,
 import Data.List.Lazy.NonEmpty as NEL
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Monoid.Additive (Additive(..))
-import Data.NonEmpty ((:|))
+import Data.NonEmpty (NonEmpty, (:|))
 import Data.Traversable (traverse)
 import Data.TraversableWithIndex (traverseWithIndex)
 import Data.Tuple (Tuple(..))
@@ -27,6 +27,7 @@ testListLazy :: Effect Unit
 testListLazy = do
   let
     l = fromFoldable
+    nel :: NonEmpty List ~> NEL.NonEmptyList
     nel xxs = NEL.NonEmptyList (Z.defer \_ -> xxs)
     longList = range 1 100000
   log "strip prefix"
@@ -458,6 +459,12 @@ testListLazy = do
 
   log "unfoldr1 should maintain order for NEL"
   assert $ (nel (1 :| l [2, 3, 4, 5])) == unfoldr1 step1 1
+
+  log "lazy Apply NEL should agree with Apply List"
+  assert $
+      l (Tuple <$> nel (1 :| l [2, 3, 4]) <*> nel ('a' :| l ['b', 'c', 'd']))
+    ==
+      (Tuple <$> l [1, 2, 3, 4] <*> l ['a', 'b', 'c', 'd'])
 
 step :: Int -> Maybe (Tuple Int Int)
 step 6 = Nothing

--- a/test/Test/Data/List/NonEmpty.purs
+++ b/test/Test/Data/List/NonEmpty.purs
@@ -281,6 +281,9 @@ testNonEmptyList = do
   log "unfoldr1 should maintain order"
   assert $ (nel 1 [2, 3, 4, 5]) == unfoldr1 step1 1
 
+  log "apply should agree with Apply List"
+  assert $ l (Tuple <$> nel 1 [2, 3, 4] <*> nel 'a' ['b', 'c', 'd']) == (Tuple <$> l [1, 2, 3, 4] <*> l ['a', 'b', 'c', 'd'])
+
 step1 :: Int -> Tuple Int (Maybe Int)
 step1 n = Tuple n (if n >= 5 then Nothing else Just (n + 1))
 


### PR DESCRIPTION
**Description of the change**

Rewrote the faulty

```purescript
instance applyNonEmptyList :: Apply NonEmptyList where
  apply (NonEmptyList (f :| fs)) (NonEmptyList (a :| as)) =
    NonEmptyList (f a :| (fs <*> a : Nil) <> ((f : fs) <*> as))
```

to

```purescript
instance applyNonEmptyList :: Apply NonEmptyList where
  apply (NonEmptyList (f :| fs)) (NonEmptyList (a :| as)) =
    NonEmptyList (f a :| map f as <> apply fs (a : as))
```

and likewise for the lazy equivalent.

A cleaner redo of my earlier PR #221.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
